### PR TITLE
Fix reading NetCDF files with incorrect dimensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 ClimaAnalysis.jl Release Notes
 ===============================
 
+v0.5.5
+------
+- Fix reading `NetCDF` files with dimensions in incorrect order.
+
 v0.5.4
 ------
 - Added support for extraction dimension from functions, such as `times`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAnalysis"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -84,10 +84,13 @@ read_var(simdir.variable_paths["hu"]["inst"])
 """
 function read_var(path::String)
     NCDatasets.NCDataset(path) do nc
-        dims = map(NCDatasets.dimnames(nc)) do dim_name
+        # First, we have to identify the name of the variable by finding what is
+        # not a dimension
+        unordered_dims = NCDatasets.dimnames(nc)
+        var_name = pop!(setdiff(keys(nc), unordered_dims))
+        dims = map(NCDatasets.dimnames(nc[var_name])) do dim_name
             return dim_name => Array(nc[dim_name])
         end |> OrderedDict
-        var_name = pop!(setdiff(keys(nc), keys(dims)))
         attribs = Dict(k => v for (k, v) in nc[var_name].attrib)
         dim_attribs = OrderedDict(
             dim_name => Dict(nc[dim_name].attrib) for dim_name in keys(dims)


### PR DESCRIPTION
As in 
```
Dataset: user_io/leaderboard/pr_30d_average.nc
Group: /

Dimensions
   lon = 180
   lat = 90
   time = 54

  pr   (54 × 180 × 90)
    Datatype:    Union{Missing, Float32} (Float32)
    Dimensions:  time × lon × lat
```

Now we read the dimensions directly from the variable.