### PR TITLE
Fix finding some variables with composed period

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 ClimaAnalysis.jl Release Notes
 ===============================
 
+v0.5.6
+------
+- Fix finding variables with name like `clwup_1m_40s_inst.nc` (composed period).
+
 v0.5.5
 ------
 - Fix reading `NetCDF` files with dimensions in incorrect order.

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -39,15 +39,14 @@ function match_nc_filename(filename::String)
     # ^ $: mean match the entire string
     # (\w+?): the first capturing group, matching any word non greedily
     # _: matches this literal character
-    # (?>([a-zA-Z0-9\.]*)_)?: an optional group (it doesn't exist for _inst variables)
-    #                         ?> means that we don't want to capture the outside group
-    #                         the inside group is any combinations of letters/numbers,
-    #                         and the literal character ., followed by the _.
-    #                         We capture the combination of characters because that's
-    #                         the reduction
+    # (?>([a-zA-Z0-9\.]*)_)?: an optional group (it doesn't always exist for _inst
+    #                         variables) ?> means that we don't want to capture the outside
+    #                         group the inside group is any combinations of letters/numbers,
+    #                         and the literal character ., followed by the _. We capture the
+    #                         combination of characters because that's the reduction
     # (\w+): Again, any word
     # \.nc: file extension has to be .nc
-    re = r"^(\w+?)_(?>([a-zA-Z0-9\.]*)_)?(\w*)\.nc$"
+    re = r"^(\w+?)_(?>([a-zA-Z0-9_\.]*)_)?(\w*)\.nc$"
     m = match(re, filename)
     if !isnothing(m)
         # m.captures returns `SubString`s (or nothing). We want to have actual `String`s (or

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -8,6 +8,9 @@ import ClimaAnalysis: Utils
     @test Utils.match_nc_filename("ta_1d_average.nc") ==
           Tuple(["ta", "1d", "average"])
 
+    @test Utils.match_nc_filename("ta_1m_40s_inst.nc") ==
+          Tuple(["ta", "1m_40s", "inst"])
+
     @test Utils.match_nc_filename("pfull_6.0min_max.nc") ==
           Tuple(["pfull", "6.0min", "max"])
 


### PR DESCRIPTION
Fixes finding variables like `clwup_1m_40s_inst.nc` (where the period has underscores)