### PR TITLE
Add Utils.warp_string

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -63,6 +63,7 @@ Utils.squeeze
 Utils.nearest_index
 Utils.kwargs
 Utils.seconds_to_prettystr
+Utils.warp_string
 ```
 
 ## Atmos

--- a/ext/GeoMakieExt.jl
+++ b/ext/GeoMakieExt.jl
@@ -48,6 +48,9 @@ function _geomakie_plot_on_globe!(
     cb_kwargs = get(more_kwargs, :cb, Dict())
     coast_kwargs = get(more_kwargs, :coast, Dict(:color => :black))
 
+    var.attributes["long_name"] =
+        ClimaAnalysis.Utils.warp_string(var.attributes["long_name"])
+
     title = get(axis_kwargs, :title, var.attributes["long_name"])
 
     GeoMakie.GeoAxis(place[p_loc...]; title, axis_kwargs...)

--- a/ext/MakieExt.jl
+++ b/ext/MakieExt.jl
@@ -61,6 +61,9 @@ function Visualize.heatmap2D!(
     plot_kwargs = get(more_kwargs, :plot, Dict())
     cb_kwargs = get(more_kwargs, :cb, Dict())
 
+    var.attributes["long_name"] =
+        ClimaAnalysis.Utils.warp_string(var.attributes["long_name"])
+
     title = get(axis_kwargs, :title, var.attributes["long_name"])
     xlabel = get(axis_kwargs, :xlabel, "$dim1_name [$dim1_units]")
     ylabel = get(axis_kwargs, :ylabel, "$dim2_name [$dim2_units]")
@@ -294,6 +297,9 @@ function Visualize.line_plot1D!(
 
     axis_kwargs = get(more_kwargs, :axis, Dict())
     plot_kwargs = get(more_kwargs, :plot, Dict())
+
+    var.attributes["long_name"] =
+        ClimaAnalysis.Utils.warp_string(var.attributes["long_name"])
 
     title = get(axis_kwargs, :title, var.attributes["long_name"])
     xlabel = get(axis_kwargs, :xlabel, "$dim_name [$dim_units]")

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,6 +1,7 @@
 module Utils
 
-export match_nc_filename, squeeze, nearest_index, kwargs, seconds_to_prettystr
+export match_nc_filename,
+    squeeze, nearest_index, kwargs, seconds_to_prettystr, warp_string
 
 """
     match_nc_filename(filename::String)
@@ -195,6 +196,56 @@ function seconds_to_prettystr(seconds::Real)
     seconds > 0 && push!(time, "$(seconds)s")
 
     return join(time, " ")
+end
+
+"""
+    warp_string(str::AbstractString)
+
+Return a string where each line is at most `max_width` characters or less
+or at most one word.
+
+Examples
+=========
+
+```jldoctest
+julia> warp_string("space", max_width = 5)
+"space"
+
+julia> warp_string("space", max_width = 4)
+"space"
+
+julia> warp_string("\\tspace    ", max_width = 4)
+"space"
+
+julia> warp_string("space space", max_width = 5)
+"space\\nspace"
+
+julia> warp_string("space space", max_width = 4)
+"space\\nspace"
+
+julia> warp_string("\\n   space  \\n  space", max_width = 4)
+"space\\nspace"
+```
+"""
+function warp_string(str::AbstractString; max_width = 42)
+    return_str = ""
+    current_width = 0
+    for word in split(str, isspace)
+        word_width = length(word)
+        if word_width + current_width <= max_width
+            return_str *= "$word "
+            current_width += word_width + 1
+        else
+            # Ensure that spaces never precede newlines
+            return_str = rstrip(return_str)
+            return_str *= "\n$word "
+            current_width = word_width + 1
+        end
+    end
+    # Remove new line character when the first word is longer than
+    # `max_width` characters and remove leading and trailing 
+    # whitespace 
+    return strip(lstrip(return_str, '\n'))
 end
 
 end

--- a/test/test_GeoMakieExt.jl
+++ b/test/test_GeoMakieExt.jl
@@ -15,7 +15,7 @@ using OrderedCollections
     data2D = reshape(1.0:(91 * 181), (181, 91))
     dims2D = OrderedDict(["lon" => long, "lat" => lat])
     attribs = Dict([
-        "long_name" => "My name",
+        "long_name" => "The quick brown fox jumps over the lazy dog. The quick brown fox.",
         "short_name" => "name",
         "units" => "bob",
     ])

--- a/test/test_MakieExt.jl
+++ b/test/test_MakieExt.jl
@@ -17,7 +17,7 @@ using OrderedCollections
     data3D = reshape(1.0:(91 * 181 * 11), (11, 181, 91))
     dims3D = OrderedDict(["time" => time, "lon" => long, "lat" => lat])
     attribs = Dict([
-        "long_name" => "My name",
+        "long_name" => "The quick brown fox jumps over the lazy dog. The quick brown fox.",
         "short_name" => "name",
         "units" => "bob",
     ])
@@ -35,7 +35,7 @@ using OrderedCollections
     data2D = reshape(1.0:(91 * 181), (181, 91))
     dims2D = OrderedDict(["lon" => long, "lat" => lat])
     attribs = Dict([
-        "long_name" => "My name",
+        "long_name" => "The quick brown fox jumps over the lazy dog. The quick brown fox.",
         "short_name" => "name",
         "units" => "bob",
     ])
@@ -83,7 +83,7 @@ using OrderedCollections
     data1D = reshape(1.0:(91), (91))
     dims1D = OrderedDict(["lat" => lat])
     attribs = Dict([
-        "long_name" => "My name",
+        "long_name" => "The quick brown fox jumps over the lazy dog. The quick brown fox.",
         "short_name" => "name",
         "units" => "bob",
     ])
@@ -167,7 +167,7 @@ using OrderedCollections
         var2D,
         more_kwargs = Dict(
             :axis => ClimaAnalysis.Utils.kwargs(
-                title = "My title",
+                title = "My title: The quick brown fox jumps over the lazy dog. The quick brown fox.",
                 xlabel = "My xlabel",
                 ylabel = "My ylabel",
             ),

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -50,3 +50,20 @@ end
 
     @test Utils.seconds_to_prettystr(24 * 60 * 60 * 365 + 68.5) == "1y 1m 8.5s"
 end
+
+@testset "format_title" begin
+    @test Utils.warp_string("") == ""
+    @test Utils.warp_string("test", max_width = 4) == "test"
+    @test Utils.warp_string("     test   ", max_width = 4) == "test"
+    @test Utils.warp_string("   test") == "test"
+    @test Utils.warp_string("test1", max_width = 4) == "test1"
+    @test Utils.warp_string("     test1   ", max_width = 4) == "test1"
+    @test Utils.warp_string("test blah", max_width = 4) == "test\nblah"
+    @test Utils.warp_string("test1 test2 test3", max_width = 4) ==
+          "test1\ntest2\ntest3"
+    @test Utils.warp_string("abc def", max_width = 3) == "abc\ndef"
+    @test Utils.warp_string("is a test", max_width = 4) == "is a\ntest"
+    @test Utils.warp_string("a b c d", max_width = 2) == "a\nb\nc\nd"
+    @test Utils.warp_string("a b c d e f", max_width = 5) == "a b c\nd e f"
+    @test Utils.warp_string("a\tb\nc\vd\fe\rf", max_width = 11) == "a b c d e f"
+end


### PR DESCRIPTION
Closes #56 - Titles can be too long for plots and overflow. The function warp_string is used by plotting functions to format the titles by adding new line characters so that each line is 42 characters or less or at most one word.