### PR TITLE
Add Utils.split_by_season

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -29,6 +29,6 @@ jobs:
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1
         with:
-          skip: Test, Statistics
+          skip: Dates, Test, Statistics
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
 version = "0.5.6"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 NaNStatistics = "b946abbf-3ea7-4610-9019-9858bfdeaf2d"
@@ -12,22 +13,23 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [weakdeps]
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [extensions]
-MakieExt = "Makie"
 GeoMakieExt = "GeoMakie"
+MakieExt = "Makie"
 
 [compat]
 Aqua = "0.8"
-Makie = "0.20.10, 0.21"
 CairoMakie = "0.11.11, 0.12"
+Dates = "1"
 Documenter = "1"
 ExplicitImports = "1.6"
 GeoMakie = "0.6.5, 0.7"
 Interpolations = "0.14, 0.15"
 JuliaFormatter = "1"
+Makie = "0.20.10, 0.21"
 NCDatasets = "0.13.1, 0.14"
 NaNStatistics = "0.6"
 OrderedCollections = "1.3"
@@ -43,8 +45,8 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -64,6 +64,7 @@ Utils.nearest_index
 Utils.kwargs
 Utils.seconds_to_prettystr
 Utils.warp_string
+Utils.split_by_season
 ```
 
 ## Atmos

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,7 +1,14 @@
 module Utils
 
 export match_nc_filename,
-    squeeze, nearest_index, kwargs, seconds_to_prettystr, warp_string
+    squeeze,
+    nearest_index,
+    kwargs,
+    seconds_to_prettystr,
+    warp_string,
+    split_by_season
+
+import Dates
 
 """
     match_nc_filename(filename::String)
@@ -246,6 +253,47 @@ function warp_string(str::AbstractString; max_width = 42)
     # `max_width` characters and remove leading and trailing 
     # whitespace 
     return strip(lstrip(return_str, '\n'))
+end
+
+"""
+    split_by_season(dates::AbstractArray{<: Dates.DateTime})
+
+Return four vectors with `dates` split by seasons. 
+
+The months of the seasons are March to May, June to August, September to November, and
+December to February. The order of the tuple is MAM, JJA, SON, and DJF.  
+
+Examples
+=========
+
+```jldoctest
+julia> import Dates
+
+julia> dates = [Dates.DateTime(2024, 1, 1), Dates.DateTime(2024, 3, 1), Dates.DateTime(2024, 6, 1), Dates.DateTime(2024, 9, 1)];
+
+julia> split_by_season(dates)
+([Dates.DateTime("2024-03-01T00:00:00")], [Dates.DateTime("2024-06-01T00:00:00")], [Dates.DateTime("2024-09-01T00:00:00")], [Dates.DateTime("2024-01-01T00:00:00")])
+``` 
+"""
+function split_by_season(dates::AbstractArray{<:Dates.DateTime})
+    MAM, JJA, SON, DJF = Vector{Dates.DateTime}(),
+    Vector{Dates.DateTime}(),
+    Vector{Dates.DateTime}(),
+    Vector{Dates.DateTime}()
+
+    for date in dates
+        if Dates.Month(3) <= Dates.Month(date) <= Dates.Month(5)
+            push!(MAM, date)
+        elseif Dates.Month(6) <= Dates.Month(date) <= Dates.Month(8)
+            push!(JJA, date)
+        elseif Dates.Month(9) <= Dates.Month(date) <= Dates.Month(11)
+            push!(SON, date)
+        else
+            push!(DJF, date)
+        end
+    end
+
+    return (MAM, JJA, SON, DJF)
 end
 
 end

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -1,5 +1,6 @@
 using Test
 import ClimaAnalysis: Utils
+import Dates
 
 @testset "Regexp" begin
 
@@ -66,4 +67,31 @@ end
     @test Utils.warp_string("a b c d", max_width = 2) == "a\nb\nc\nd"
     @test Utils.warp_string("a b c d e f", max_width = 5) == "a b c\nd e f"
     @test Utils.warp_string("a\tb\nc\vd\fe\rf", max_width = 11) == "a b c d e f"
+end
+
+@testset "split by season" begin
+    empty_dates = Vector{Dates.DateTime}()
+    @test Utils.split_by_season(empty_dates) == ([], [], [], [])
+
+    date = [Dates.DateTime(2015, 4, 13)]
+    @test Utils.split_by_season(date) ==
+          ([Dates.DateTime(2015, 4, 13)], [], [], [])
+
+    dates = [
+        Dates.DateTime(2015, 1, 13),
+        Dates.DateTime(2018, 2, 13),
+        Dates.DateTime(1981, 7, 6),
+        Dates.DateTime(1993, 11, 19),
+        Dates.DateTime(2040, 4, 1),
+        Dates.DateTime(2000, 8, 18),
+    ]
+
+    expected_dates = (
+        [Dates.DateTime(2040, 4, 1)],
+        [Dates.DateTime(1981, 7, 6), Dates.DateTime(2000, 8, 18)],
+        [Dates.DateTime(1993, 11, 19)],
+        [Dates.DateTime(2015, 1, 13), Dates.DateTime(2018, 2, 13)],
+    )
+
+    @test Utils.split_by_season(dates) == expected_dates
 end


### PR DESCRIPTION
Closes #59 - The function split_by_season is in ClimaCoupler and should be moved to ClimaAnalysis. Also, the Dates package is added as a dependency because split_by_season operate on dates.