### PR TITLE
Add Visualize._constrained_cmap

### DIFF
--- a/test/test_GeoMakieExt.jl
+++ b/test/test_GeoMakieExt.jl
@@ -35,9 +35,58 @@ using OrderedCollections
 
     fig2 = Makie.Figure()
 
-    ClimaAnalysis.Visualize.contour2D_on_globe!(fig2, var2D)
+    ClimaAnalysis.Visualize.contour2D_on_globe!(
+        fig2,
+        var2D,
+        more_kwargs = Dict(
+            :plot =>
+                ClimaAnalysis.Utils.kwargs(colormap = Makie.colorschemes[:vik]),
+        ),
+    )
 
     output_name = joinpath(tmp_dir, "test_contours2D_globe.png")
     Makie.save(output_name, fig2)
+
+    # Test cmap 
+    MakieExt = Base.get_extension(ClimaAnalysis, :MakieExt)
+    test_cmap = MakieExt._constrained_cmap(
+        Makie.colorschemes[:vik],
+        0.0,
+        15000.0 + (5000.0 / 3.0),
+        mid = 5000.0,
+        categorical = true,
+    )
+
+    fig3 = Makie.Figure()
+
+    ClimaAnalysis.Visualize.contour2D_on_globe!(
+        fig3,
+        var2D,
+        more_kwargs = Dict(
+            :plot => ClimaAnalysis.Utils.kwargs(colormap = test_cmap),
+        ),
+    )
+
+    output_name = joinpath(tmp_dir, "test_contours2D_globe_with_test_cmap.png")
+    Makie.save(output_name, fig3)
+
+    test_cmap = MakieExt._constrained_cmap(
+        range(Makie.colorant"red", stop = Makie.colorant"green", length = 15),
+        0.0,
+        15000.0 + (5000.0 / 3.0),
+    )
+
+    fig4 = Makie.Figure()
+
+    ClimaAnalysis.Visualize.contour2D_on_globe!(
+        fig4,
+        var2D,
+        more_kwargs = Dict(
+            :plot => ClimaAnalysis.Utils.kwargs(colormap = test_cmap),
+        ),
+    )
+
+    output_name = joinpath(tmp_dir, "test_contours2D_globe_with_test_cmap2.png")
+    Makie.save(output_name, fig4)
 
 end


### PR DESCRIPTION
Closes #62 - The function constrained_cmap is in ClimaCoupler and should be moved to ClimaAnalysis. 

See image below for a plot using constrained_cmap. 
![test_contours2D_globe_with_test_cmap](https://github.com/user-attachments/assets/ee16578f-e000-4dc8-8c78-be8f3a247dce)

See image below for a plot not using constrained_cmap. 
![test_contours2D_globe](https://github.com/user-attachments/assets/4464ef4e-718d-4311-b62e-51a670a12f0b)