### PR TITLE
Update docstring for warp_string and increase max

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -206,7 +206,7 @@ function seconds_to_prettystr(seconds::Real)
 end
 
 """
-    warp_string(str::AbstractString)
+    warp_string(str::AbstractString; max_width = 70)
 
 Return a string where each line is at most `max_width` characters or less
 or at most one word.
@@ -234,7 +234,7 @@ julia> warp_string("\\n   space  \\n  space", max_width = 4)
 "space\\nspace"
 ```
 """
-function warp_string(str::AbstractString; max_width = 42)
+function warp_string(str::AbstractString; max_width = 70)
     return_str = ""
     current_width = 0
     for word in split(str, isspace)


### PR DESCRIPTION
42 is a little too short, especially when defaults are used

See here as an example with 42

![image](https://github.com/user-attachments/assets/cb8e6df7-3ab9-4480-ba4a-e4eb9d79f194)
