### PR TITLE
Add Var.resampled_as

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,47 @@ myfile = OutputVar("my_netcdf_file.nc", "myvar")
 
 [0] Restrictions apply.
 
+### Resampling a `OutputVar` using the dimensions from another `OutputVar`
+
+You can use the `resampled_as(src_var, dest_var)` function where `src_var` is a
+OutputVar with the data you want to resample using the dimensions in another
+OutputVar `dest_var`. If resampling is possible, then a new `OutputVar` is
+returned where the data in `src_var` is resampled using a linear interpolation
+to fit the dimensions in `dest_var`. Resampling is not possible when the
+dimensions in either `OutputVar`s are missing units, the dimensions between the
+`OutputVar`s do not agree, or the data in `src_var` is not defined everywhere on
+the dimensions in `dest_var`.
+
+```julia
+julia> src_var.data
+3×4 Matrix{Float64}:
+ 1.0  4.0  7.0  10.0
+ 2.0  5.0  8.0  11.0
+ 3.0  6.0  9.0  12.0
+
+julia> src_var.dims
+OrderedDict{String, Vector{Float64}} with 2 entries:
+  "lon"      => [0.0, 1.0, 2.0]
+  "latitude" => [0.0, 1.0, 2.0, 3.0]
+
+julia> dest_var.dims # dims that src_var.data should be resampled on
+OrderedDict{String, Vector{Float64}} with 2 entries:
+  "long" => [0.0, 1.0]
+  "lat"  => [0.0, 1.0, 2.0]
+
+julia> resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var);
+
+julia> resampled_var.data
+2×3 Matrix{Float64}:
+ 1.0  4.0  7.0
+ 2.0  5.0  8.0
+
+julia> resampled_var.dims # updated dims that are the same as the dims in dest_var
+OrderedDict{String, Vector{Float64}} with 2 entries:
+  "lon"      => [0.0, 1.0]
+  "latitude" => [0.0, 1.0, 2.0]
+```
+
 ## Bug fixes
 
 - Increased the default value for `warp_string` to 72.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -49,8 +49,10 @@ Var.has_date
 Var.has_longitude
 Var.has_latitude
 Var.has_altitude
+Var.conventional_dim_name
 Var.dim_units
 Var.range_dim
+Var.resampled_as
 ```
 
 ## Utilities

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -67,3 +67,43 @@ The `Atmos` module in `ClimaAnalysis` comes with a function,
 `OutputVar` is returned where the values are linearly interpolated on fixed
 pressure levels.
 
+## How do I resample the data in a `OutputVar` using the dimensions from another `OutputVar`?
+
+You can use the `resampled_as(src_var, dest_var)` function where `src_var` is a
+OutputVar with the data you want to resample using the dimensions in another
+OutputVar `dest_var`. If resampling is possible, then a new `OutputVar` is
+returned where the data in `src_var` is resampled using a linear interpolation
+to fit the dimensions in `dest_var`. Resampling is not possible when the
+dimensions in either `OutputVar`s are missing units, the dimensions between the
+`OutputVar`s do not agree, or the data in `src_var` is not defined everywhere on
+the dimensions in `dest_var`.
+
+```@julia resampled_as
+julia> src_var.data
+3×4 Matrix{Float64}:
+ 1.0  4.0  7.0  10.0
+ 2.0  5.0  8.0  11.0
+ 3.0  6.0  9.0  12.0
+
+julia> src_var.dims
+OrderedDict{String, Vector{Float64}} with 2 entries:
+  "lon"      => [0.0, 1.0, 2.0]
+  "latitude" => [0.0, 1.0, 2.0, 3.0]
+
+julia> dest_var.dims # dims that src_var.data should be resampled on
+OrderedDict{String, Vector{Float64}} with 2 entries:
+  "long" => [0.0, 1.0]
+  "lat"  => [0.0, 1.0, 2.0]
+
+julia> resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var);
+
+julia> resampled_var.data
+2×3 Matrix{Float64}:
+ 1.0  4.0  7.0
+ 2.0  5.0  8.0
+
+julia> resampled_var.dims # updated dims that are the same as the dims in dest_var
+OrderedDict{String, Vector{Float64}} with 2 entries:
+  "lon"      => [0.0, 1.0]
+  "latitude" => [0.0, 1.0, 2.0]
+```

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -19,7 +19,8 @@ export times,
     has_date,
     has_longitude,
     has_latitude,
-    has_altitude
+    has_altitude,
+    conventional_dim_name
 
 """
     _dim_name(dim_names, allowed_names)
@@ -167,3 +168,18 @@ altitude_name(var::OutputVar) = find_dim_name(keys(var.dims), ALTITUDE_NAMES)
 Return the `altitude` dimension in `var`.
 """
 altitudes(var::OutputVar) = var.dims[altitude_name(var)]
+
+"""
+    conventional_dim_name(dim_name::AbstractString)
+
+Return the type of dimension as a string from longitude, latitude, time, date, or altitude
+if possible or `dim_name` as a string otherwise.
+"""
+function conventional_dim_name(dim_name::AbstractString)
+    dim_name in LONGITUDE_NAMES && return "longitude"
+    dim_name in LATITUDE_NAMES && return "latitude"
+    dim_name in TIME_NAMES && return "time"
+    dim_name in DATE_NAMES && return "date"
+    dim_name in ALTITUDE_NAMES && return "altitude"
+    return dim_name
+end


### PR DESCRIPTION
closes #65 - This PR add `Var.resampled_as` which has the same functionality as `resample` in ClimaCoupler. Additionally, `Var._check_dims_consistent` is made to help with checking that the `dim` in two OutputVar are consistent. Lastly, Var.dim_type is added to find the type of a dimension given the name of the dimension.