### PR TITLE
Add Var.integrate* functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,6 +120,50 @@ contour2D_on_globe!(fig,
 CairoMakie.save("myfigure.pdf", fig)
 ```
 
+## Integrating `OutputVar` with respect to longitude or latitude
+
+You can use the `integrate_lon(var)`, `integrate_lat(var)`, or `integrate_lonlat(var)`
+functions for integrating along longitude, latitude, or both respectively. The bounds of
+integration are determined by the range of the dimensions longitude and latitude in `var`.
+The unit of both longitude and latitude should be degree.
+
+If the points are equispaced, it is assumed that each point correspond to the midpoint of a
+cell which results in rectangular integration using the midpoint rule. Otherwise, the
+integration being done is rectangular integration using the left endpoints for integrating
+longitude and latitude. See the example of integrating over a sphere where the data is all
+ones to find the surface area of a sphere.
+
+```@julia integrate_lonlat
+julia> lon = collect(range(-179.5, 179.5, 360));
+
+julia> lat = collect(range(-89.5, 89.5, 180));
+
+julia> data = ones(length(lon), length(lat));
+
+julia> dims = OrderedDict(["lon" => lon, "lat" => lat]);
+
+julia> dim_attribs = OrderedDict([
+           "lon" => Dict("units" => "degrees_east"),
+           "lat" => Dict("units" => "degrees_north"),
+       ]);
+
+julia> attribs = Dict("long_name" => "f");
+
+julia> var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data);
+
+julia> integrated_var = integrate_lonlat(var);
+
+julia> integrated_var.dims # no dimensions since longitude and latitude are integrated out
+OrderedDict{String, Vector{Float64}}()
+
+julia> integrated_var.data # approximately 4π (the surface area of a sphere)
+0-dimensional Array{Float64, 0}:
+12.566530113084296
+
+julia> long_name(integrated_var) # updated long name to reflect the data being integrated
+"f integrated over lon (-179.5 to 179.5degrees_east) and integrated over lat (-89.5 to 89.5degrees_north)"
+```
+
 ## Bug fixes
 
 - Increased the default value for `warp_string` to 72.

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaAnalysis"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
-authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
+authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
 version = "0.5.7"
 
 [deps]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -55,6 +55,9 @@ Var.dim_units
 Var.range_dim
 Var.resampled_as
 Var.convert_units
+Var.integrate_lonlat
+Var.integrate_lat
+Var.integrate_lon
 ```
 
 ## Utilities

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -54,3 +54,49 @@ new_var = ClimaAnalysis.convert_units(var, "kg m/s", conversion_function = (x) -
 ```
 
 !!! note If you find some unparseable units, please open an issue. We can fix them!
+
+## Integration
+
+`OutputVar`s can be integrated with respect to longitude, latitude, or both using
+`integrate_lon(var)`, `integrate_lat(var)`, or `integrate_lonlat(var)` respectively. The
+bounds of integration are determined by the range of the dimensions longitude and latitude
+in `var`. The unit of both longitude and latitude should be degree.
+
+If the points are equispaced, it is assumed that each point correspond to the midpoint of a
+cell which results in rectangular integration using the midpoint rule. Otherwise, the
+integration being done is rectangular integration using the left endpoints for integrating
+longitude and latitude.
+
+See the example of integrating over a sphere where the data is all ones to find the surface
+area of a sphere.
+
+```@julia integrate_lonlat
+julia> lon = collect(range(-179.5, 179.5, 360));
+
+julia> lat = collect(range(-89.5, 89.5, 180));
+
+julia> data = ones(length(lon), length(lat));
+
+julia> dims = OrderedDict(["lon" => lon, "lat" => lat]);
+
+julia> dim_attribs = OrderedDict([
+           "lon" => Dict("units" => "degrees_east"),
+           "lat" => Dict("units" => "degrees_north"),
+       ]);
+
+julia> attribs = Dict("long_name" => "f");
+
+julia> var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data);
+
+julia> integrated_var = integrate_lonlat(var);
+
+julia> integrated_var.dims # no dimensions since longitude and latitude are integrated out
+OrderedDict{String, Vector{Float64}}()
+
+julia> integrated_var.data # approximately 4π (the surface area of a sphere)
+0-dimensional Array{Float64, 0}:
+12.566530113084296
+
+julia> long_name(integrated_var) # updated long name to reflect the data being integrated
+"f integrated over lon (-179.5 to 179.5degrees_east) and integrated over lat (-89.5 to 89.5degrees_north)"
+```

--- a/src/ClimaAnalysis.jl
+++ b/src/ClimaAnalysis.jl
@@ -4,6 +4,8 @@ import Reexport: @reexport
 include("Utils.jl")
 import .Utils
 
+include("Numerics.jl")
+
 include("Var.jl")
 @reexport using .Var
 include("Sim.jl")

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -1,0 +1,128 @@
+module Numerics
+
+import ..Utils: _isequispaced
+
+"""
+    _integrate_lon(data::AbstractArray, lon::AbstractVector; dims)
+
+Integrate out longitude from `data`. `data` has to be discretized on `lon`.
+
+`dims` indicates which axis of `data` is longitude.
+
+If the points are equispaced, it is assumed that each point correspond to the midpoint of a
+cell which results in rectangular integration using the midpoint rule. Otherwise, the
+integration being done is rectangular integration using the left endpoints. The unit for
+longitude should be degrees.
+"""
+function _integrate_lon(data::AbstractArray, lon::AbstractVector; dims)
+    length(lon) == 1 &&
+        error("Cannot integrate when longitude is a single point")
+    _isequispaced(lon) ?
+    int_weights = _integration_weights_lon_equispaced(lon) :
+    int_weights = _integration_weights_lon_left(lon)
+    return _integrate_over_angle(data, lon, dims, int_weights)
+end
+
+"""
+    _integrate_lat(data::AbstractArray, lat::AbstractVector; dims)
+
+Integrate out latitude from `data`. `data` has to be discretized on `lat`.
+
+`dims` indicates which axis of `data` is latitude.
+
+If the points are equispaced, it is assumed that each point correspond to the midpoint of a
+cell which results in rectangular integration using the midpoint rule. Otherwise, the
+integration being done is rectangular integration using the left endpoints. The unit for
+latitude should be degrees.
+"""
+function _integrate_lat(data::AbstractArray, lat::AbstractVector; dims)
+    length(lat) == 1 &&
+        error("Cannot integrate when latitude is a single point")
+    _isequispaced(lat) ?
+    int_weights = _integration_weights_lat_equispaced(lat) :
+    int_weights = _integration_weights_lat_left(lat)
+    return _integrate_over_angle(data, lat, dims, int_weights)
+end
+
+"""
+    _integrate_over_angle(
+    data::AbstractArray,
+    angle_arr::AbstractVector,
+    angle_idx,
+    int_weights::AbstractVector,
+)
+
+Integrate out angle (latitude or longitude) from `data` using the weights `int_weights`.
+`data` has to be discretized on `angle_arr`.
+
+`angle_idx` indicates which axis of `data` is angle.
+"""
+function _integrate_over_angle(
+    data::AbstractArray,
+    angle_arr::AbstractVector,
+    angle_idx,
+    int_weights,
+)
+    # Reshape to add extra dimensions for int_weights for broadcasting if needed
+    size_to_reshape =
+        (i == angle_idx ? length(int_weights) : 1 for i in 1:ndims(data))
+    int_weights = reshape(int_weights, size_to_reshape...)
+    int_on_angle = sum(data .* int_weights, dims = angle_idx)
+    return int_on_angle
+end
+
+"""
+    _integration_weights_lon_left(lon)
+
+Return integration weights for rectangular integration using left endpoints for integrating
+along longitude.
+"""
+function _integration_weights_lon_left(lon)
+    # This is where we use the assumption that units are degrees
+    d_lon = deg2rad.(diff(lon))
+    # We are doing integration using the left endpoints, so we weight the rightmost endpoint
+    # zero so that it make no contribution to the integral
+    push!(d_lon, zero(eltype(d_lon)))
+    return d_lon
+end
+
+"""
+    _integration_weights_lat_left(lat)
+
+Return integration weights for rectangular integration using left endpoints for integrating
+along latitude.
+"""
+function _integration_weights_lat_left(lat)
+    d_lat = deg2rad.(diff(lat))
+    # We are doing integration using the left endpoints, so we weight the rightmost endpoint
+    # zero so that it make no contribution to the integral
+    push!(d_lat, zero(eltype(d_lat)))
+    cos_lat = cosd.(lat)
+    return d_lat .* cos_lat
+end
+
+"""
+    _integration_weights_lon_equispaced(lon)
+
+Return integration weights for rectangular integration when the points are equispaced for
+integrating along longitude.
+"""
+function _integration_weights_lon_equispaced(lon)
+    # This is where we use the assumption that units are degrees
+    # Use fill to make a zero dimensional array so reshaping is possible
+    return fill(deg2rad(lon[begin + 1] - lon[begin]))
+end
+
+"""
+    _integration_weights_lat_equispaced(lat)
+
+Return integration weights for rectangular integration when the points are equispaced for
+integrating along latitude.
+"""
+function _integration_weights_lat_equispaced(lat)
+    d_lat = deg2rad.(lat[begin + 1] - lat[begin])
+    cos_lat = cosd.(lat)
+    return d_lat .* cos_lat
+end
+
+end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -296,4 +296,24 @@ function split_by_season(dates::AbstractArray{<:Dates.DateTime})
     return (MAM, JJA, SON, DJF)
 end
 
+"""
+    _isequispaced(arr::Vector)
+
+Return whether the array is equispaced or not.
+
+Examples
+=========
+
+```jldoctest
+julia> Utils._isequispaced([1.0, 2.0, 3.0])
+true
+
+julia> Utils._isequispaced([0.0, 2.0, 3.0])
+false
+```
+"""
+function _isequispaced(arr::Vector)
+    return all(diff(arr) .≈ arr[begin + 1] - arr[begin])
+end
+
 end

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -388,7 +388,7 @@ function average_lat(var; ignore_nan = true, weighted = false)
     weighted &&
         haskey(var.attributes, "long_name") &&
         (reduced_var.attributes["long_name"] *= " weighted")
-    _update_long_name_average!(reduced_var, var, latitude_name(var))
+    _update_long_name_generic!(reduced_var, var, latitude_name(var), "averaged")
 
 
     return reduced_var
@@ -412,7 +412,12 @@ Return a new OutputVar where the values on the longitudes are averaged arithmeti
 function average_lon(var; ignore_nan = true)
     reduced_var =
         _reduce_over(ignore_nan ? nanmean : mean, longitude_name(var), var)
-    _update_long_name_average!(reduced_var, var, longitude_name(var))
+    _update_long_name_generic!(
+        reduced_var,
+        var,
+        longitude_name(var),
+        "averaged",
+    )
     return reduced_var
 end
 
@@ -423,7 +428,7 @@ Return a new OutputVar where the values along the `x` dimension are averaged ari
 """
 function average_x(var; ignore_nan = true)
     reduced_var = _reduce_over(ignore_nan ? nanmean : mean, "x", var)
-    _update_long_name_average!(reduced_var, var, "x")
+    _update_long_name_generic!(reduced_var, var, "x", "averaged")
     return reduced_var
 end
 
@@ -434,7 +439,7 @@ Return a new OutputVar where the values along the `y` dimension are averaged ari
 """
 function average_y(var; ignore_nan = true)
     reduced_var = _reduce_over(ignore_nan ? nanmean : mean, "y", var)
-    _update_long_name_average!(reduced_var, var, "y")
+    _update_long_name_generic!(reduced_var, var, "y", "averaged")
     return reduced_var
 end
 
@@ -466,7 +471,7 @@ Return a new OutputVar where the values are averaged arithmetically in time.
 """
 function average_time(var; ignore_nan = true)
     reduced_var = _reduce_over(ignore_nan ? nanmean : mean, time_name(var), var)
-    _update_long_name_average!(reduced_var, var, time_name(var))
+    _update_long_name_generic!(reduced_var, var, time_name(var), "averaged")
     return reduced_var
 end
 
@@ -500,21 +505,27 @@ function range_dim(var::OutputVar, dim_name)
 end
 
 """
-    _update_long_name_average!(reduced_var::OutputVar, var::OutputVar, dim_name)
-
-Used by averaging functions to update the long name of `reduced_var` by describing what the
-average is being taken over and the associated units.
-"""
-function _update_long_name_average!(
+    _update_long_name_generic!(
     reduced_var::OutputVar,
     var::OutputVar,
     dim_name,
+    operation_name,
+)
+
+Used by reducing functions to update the long name of `reduced_var` by describing the
+operation being used to reduce the data and the associated units.
+"""
+function _update_long_name_generic!(
+    reduced_var::OutputVar,
+    var::OutputVar,
+    dim_name,
+    operation_name,
 )
     dim_of_units = dim_units(var, dim_name)
     first_elt, last_elt = range_dim(var, dim_name)
 
     if haskey(var.attributes, "long_name")
-        reduced_var.attributes["long_name"] *= " averaged over $dim_name ($first_elt to $last_elt$dim_of_units)"
+        reduced_var.attributes["long_name"] *= " $operation_name over $dim_name ($first_elt to $last_elt$dim_of_units)"
     end
     return nothing
 end

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -306,7 +306,7 @@ function Base.copy(var::OutputVar)
 end
 
 """
-    _reduce_over(reduction::F, dim::String, var::OutputVar)
+    _reduce_over(reduction::F, dim::String, var::OutputVar, args...; kwargs...)
 
 Apply the given reduction over the given dimension.
 
@@ -340,7 +340,10 @@ function _reduce_over(
     dim_index = var.dim2index[dim]
 
     # squeeze removes the unnecessary singleton dimension
-    data = squeeze(reduction(var.data, dims = dim_index), dims = (dim_index,))
+    data = squeeze(
+        reduction(var.data, args..., dims = dim_index, kwargs...),
+        dims = (dim_index,),
+    )
 
     # If we reduce over a dimension, we have to remove it
     dims = copy(var.dims)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,15 +2,16 @@ using SafeTestsets
 using Test
 
 #! format: off
-# @safetestset "Aqua" begin @time include("aqua.jl") end
-# @safetestset "Docstrings" begin @time include("doctest.jl") end
-# @safetestset "Format" begin @time include("format.jl") end
+@safetestset "Aqua" begin @time include("aqua.jl") end
+@safetestset "Docstrings" begin @time include("doctest.jl") end
+@safetestset "Format" begin @time include("format.jl") end
 
-# @safetestset "Utils" begin @time include("test_Utils.jl") end
-# @safetestset "SimDir" begin @time include("test_Sim.jl") end
-# @safetestset "Atmos" begin @time include("test_Atmos.jl") end
-# @safetestset "OutputVar" begin @time include("test_Var.jl") end
-# @safetestset "MakieExt" begin @time include("test_MakieExt.jl") end
+@safetestset "Utils" begin @time include("test_Utils.jl") end
+@safetestset "Numerics" begin @time include("test_Numerics.jl") end
+@safetestset "SimDir" begin @time include("test_Sim.jl") end
+@safetestset "Atmos" begin @time include("test_Atmos.jl") end
+@safetestset "OutputVar" begin @time include("test_Var.jl") end
+@safetestset "MakieExt" begin @time include("test_MakieExt.jl") end
 @safetestset "GeoMakieExt" begin @time include("test_GeoMakieExt.jl") end
 #! format: on
 

--- a/test/test_Numerics.jl
+++ b/test/test_Numerics.jl
@@ -1,0 +1,113 @@
+using Test
+import ClimaAnalysis
+
+@testset "integration weights for lon and lat" begin
+    # Integration weights for lon (not equispaced)
+    lon = [-180.0, -45.0, 100.0, 180.0]
+    lon_weights = [135.0, 145.0, 80.0, 0.0] .* (π / 180.0)
+    @test all(
+        isapprox.(
+            lon_weights,
+            ClimaAnalysis.Numerics._integration_weights_lon_left(lon),
+        ),
+    )
+
+    # Integration weights for lat (not equispaced)
+    lat = [-90.0, 20.0, 45.0, 90.0]
+    lat_weights = [110.0, 25.0, 45.0, 0.0] .* (π / 180.0) .* cosd.(lat)
+    @test all(
+        isapprox.(
+            lat_weights,
+            ClimaAnalysis.Numerics._integration_weights_lat_left(lat),
+        ),
+    )
+
+    # Integration weights for lon (not equispaced)
+    lon = collect(range(-180.0, 180.0, 5))
+    lon_weights = [90.0 for _ in lon] .* (π / 180.0)
+    @test all(
+        isapprox.(
+            lon_weights,
+            ClimaAnalysis.Numerics._integration_weights_lon_equispaced(lon),
+        ),
+    )
+
+    lat = collect(range(-90.0, 90.0, 5))
+    lat_weights = [45.0 for _ in lat] .* (π / 180.0) .* cosd.(lat)
+    @test all(
+        isapprox.(
+            lat_weights,
+            ClimaAnalysis.Numerics._integration_weights_lat_equispaced(lat),
+        ),
+    )
+end
+
+@testset "Integrating on lon and lat" begin
+    # Integrating only lon (non equispaced)
+    lon = collect(range(-180.0, 179.0, 100))
+    # Force array to be non equispaced for testing _integration_weights_lon
+    push!(lon, 180.0)
+    lon_data = ones(length(lon))
+    @test isapprox(
+        ClimaAnalysis.Numerics._integrate_lon(lon_data, lon, dims = 1)[1],
+        2.0π,
+        atol = 0.01,
+    )
+
+    # Integrating only lat (non equispaced)
+    lat = collect(range(-90.0, 89.0, 100))
+    # Force array to be non equispaced for testing _integration_weights_lat
+    push!(lat, 90.0)
+    lat_data = ones(length(lat))
+    @test isapprox(
+        ClimaAnalysis.Numerics._integrate_lat(lat_data, lat, dims = 1)[1],
+        2.0,
+        atol = 0.01,
+    )
+
+    # Integrating both lon and lat
+    data = ones(length(lat), length(lon))
+    integrated_lat = ClimaAnalysis.Numerics._integrate_lat(data, lat, dims = 1)
+    integrated_latlon =
+        ClimaAnalysis.Numerics._integrate_lon(integrated_lat, lon, dims = 1)
+
+    integrated_lon = ClimaAnalysis.Numerics._integrate_lon(data, lon, dims = 2)
+    integrated_lonlat =
+        ClimaAnalysis.Numerics._integrate_lat(integrated_lon, lat, dims = 1)
+
+    # Order of integration should not matter
+    @test isapprox(integrated_latlon[1], integrated_lonlat[1])
+    @test isapprox(integrated_latlon[1], 4π, atol = 0.01)
+
+    # Error checking for length of lon and lat and values in lon and lat
+    @test_throws "Cannot integrate when latitude is a single point" ClimaAnalysis.Numerics._integrate_lat(
+        lat_data,
+        [0.0],
+        dims = 1,
+    )
+
+    @test_throws "Cannot integrate when latitude is a single point" ClimaAnalysis.Numerics._integrate_lat(
+        lon_data,
+        [0.0],
+        dims = 1,
+    )
+
+    # Integrating only lon (non equispaced)
+    lon = collect(range(-179.5, 179.5, 360))
+    lon_data = ones(length(lon))
+    @test isapprox(
+        ClimaAnalysis.Numerics._integrate_lon(lon_data, lon, dims = 1)[1],
+        2.0π,
+        atol = 0.01,
+    )
+
+    # Integrating only lat (non equispaced)
+    lat = collect(range(-89.5, 89.5, 180))
+    lat_data = ones(length(lat))
+    @test isapprox(
+        ClimaAnalysis.Numerics._integrate_lat(lat_data, lat, dims = 1)[1],
+        2.0,
+        atol = 0.01,
+    )
+
+end

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -95,3 +95,11 @@ end
 
     @test Utils.split_by_season(dates) == expected_dates
 end
+
+@testset "equispaced" begin
+    equispaced = Utils._isequispaced([1.0, 2.0, 3.0])
+    @test equispaced == true
+
+    equispaced = Utils._isequispaced([0.0, 2.0, 3.0])
+    @test equispaced == false
+end


### PR DESCRIPTION
Closes #75 - This PR port the functionality of integrating `OutputVar` to ClimaAnalysis from ClimaCoupler. In particular, `Var.integrate_lonlat`, `Var.integrate_lon`, and `Var.integrate_lat` for integrating `OutputVar` with respect to longitude, latitude, or
both. Additionally, this commit adds a Numerics module to decouple the numerical implementation of integration and the construction of an `OutputVar`. The numerical implementation is rectangular integration using the midpoint rule when the points are equispaced which assume each point correspond to a midpoint of a cell and using the left endpoint rule when the points are not equispaced.

Lastly, `update_long_name_average!` is replaced by `update_long_name_generic!` so that the integrating functions can also use this function. Also, `_reduce_over` take in `args` and `kwargs` in `squeeze`.