### PR TITLE
Add Var.split_by_season

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,7 +120,7 @@ contour2D_on_globe!(fig,
 CairoMakie.save("myfigure.pdf", fig)
 ```
 
-## Integrating `OutputVar` with respect to longitude or latitude
+### Integrating `OutputVar` with respect to longitude or latitude
 
 You can use the `integrate_lon(var)`, `integrate_lat(var)`, or `integrate_lonlat(var)`
 functions for integrating along longitude, latitude, or both respectively. The bounds of

--- a/NEWS.md
+++ b/NEWS.md
@@ -164,6 +164,46 @@ julia> long_name(integrated_var) # updated long name to reflect the data being i
 "f integrated over lon (-179.5 to 179.5degrees_east) and integrated over lat (-89.5 to 89.5degrees_north)"
 ```
 
+### Split by season
+`OutputVar`s can be split by seasons using `split_by_season(var)` provided that a start date
+can be found in `var.attributes["start_date"]` and time is a dimension in the `OutputVar`.
+The unit of time is expected to be second. The function `split_by_season(var)` returns a
+vector of four `OutputVar`s with each `OutputVar` corresponding to a season. The months of
+the seasons are March to May, June to August, September to November, and December to
+February. The order of the vector is MAM, JJA, SON, and DJF. If there are no dates found for
+a season, then the `OutputVar` for that season will be an empty `OutputVar`.
+
+```@julia split_by_season
+julia> attribs = Dict("start_date" => "2024-1-1");
+
+julia> time = [0.0, 5_184_000.0, 13_132_800.0]; # correspond to dates 2024-1-1, 2024-3-1, 2024-6-1
+
+julia> dims = OrderedDict(["time" => time]);
+
+julia> dim_attribs = OrderedDict(["time" => Dict("units" => "s")]); # unit is second
+
+julia> data = [1.0, 2.0, 3.0];
+
+julia> var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data);
+
+julia> MAM, JJA, SON, DJF = ClimaAnalysis.split_by_season(var);
+
+julia> ClimaAnalysis.isempty(SON) # empty OutputVar because no dates between September to November
+true
+
+julia> [MAM.dims["time"], JJA.dims["time"], DJF.dims["time"]]
+3-element Vector{Vector{Float64}}:
+ [5.184e6]
+ [1.31328e7]
+ [0.0]
+
+julia> [MAM.data, JJA.data, DJF.data]
+3-element Vector{Vector{Float64}}:
+ [2.0]
+ [3.0]
+ [1.0]
+```
+
 ## Bug fixes
 
 - Increased the default value for `warp_string` to 72.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -72,7 +72,6 @@ Utils.nearest_index
 Utils.kwargs
 Utils.seconds_to_prettystr
 Utils.warp_string
-Utils.split_by_season
 ```
 
 ## Atmos

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -20,6 +20,7 @@ Sim.available_periods
 Var.OutputVar
 Var.read_var
 Var.is_z_1D
+Base.isempty(var::OutputVar)
 Var.short_name
 Var.long_name
 Var.units

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -59,6 +59,7 @@ Var.convert_units
 Var.integrate_lonlat
 Var.integrate_lat
 Var.integrate_lon
+Var.split_by_season(var::OutputVar)
 ```
 
 ## Utilities

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -100,3 +100,43 @@ julia> integrated_var.data # approximately 4π (the surface area of a sphere)
 julia> long_name(integrated_var) # updated long name to reflect the data being integrated
 "f integrated over lon (-179.5 to 179.5degrees_east) and integrated over lat (-89.5 to 89.5degrees_north)"
 ```
+
+## Split by season
+`OutputVar`s can be split by seasons using `split_by_season(var)` provided that a start date
+can be found in `var.attributes["start_date"]` and time is a dimension in the `OutputVar`.
+The unit of time is expected to be second. The function `split_by_season(var)` returns a
+vector of four `OutputVar`s with each `OutputVar` corresponding to a season. The months of
+the seasons are March to May, June to August, September to November, and December to
+February. The order of the vector is MAM, JJA, SON, and DJF. If there are no dates found for
+a season, then the `OutputVar` for that season will be an empty `OutputVar`.
+
+```@julia split_by_season
+julia> attribs = Dict("start_date" => "2024-1-1");
+
+julia> time = [0.0, 5_184_000.0, 13_132_800.0]; # correspond to dates 2024-1-1, 2024-3-1, 2024-6-1
+
+julia> dims = OrderedDict(["time" => time]);
+
+julia> dim_attribs = OrderedDict(["time" => Dict("units" => "s")]); # unit is second
+
+julia> data = [1.0, 2.0, 3.0];
+
+julia> var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data);
+
+julia> MAM, JJA, SON, DJF = ClimaAnalysis.split_by_season(var);
+
+julia> ClimaAnalysis.isempty(SON) # empty OutputVar because no dates between September to November
+true
+
+julia> [MAM.dims["time"], JJA.dims["time"], DJF.dims["time"]]
+3-element Vector{Vector{Float64}}:
+ [5.184e6]
+ [1.31328e7]
+ [0.0]
+
+julia> [MAM.data, JJA.data, DJF.data]
+3-element Vector{Vector{Float64}}:
+ [2.0]
+ [3.0]
+ [1.0]
+```

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,12 +1,7 @@
 module Utils
 
 export match_nc_filename,
-    squeeze,
-    nearest_index,
-    kwargs,
-    seconds_to_prettystr,
-    warp_string,
-    split_by_season
+    squeeze, nearest_index, kwargs, seconds_to_prettystr, warp_string
 
 import Dates
 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -316,4 +316,34 @@ function _isequispaced(arr::Vector)
     return all(diff(arr) .≈ arr[begin + 1] - arr[begin])
 end
 
+"""
+    _data_at_dim_vals(data, dim_arr, dim_idx, vals)
+
+Return a view of `data` by slicing along `dim_idx`. The slices are indexed by the indices
+corresponding to values in `dim_arr` closest to the values in `vals`.
+
+Examples
+=========
+
+```jldoctest
+julia> data = [[1, 4, 7]  [2, 5, 8]  [3, 6, 9]];
+
+julia> dim_arr = [1.0, 2.0, 4.0];
+
+julia> dim_idx = 2;
+
+julia> vals = [1.1, 4.0];
+
+julia> Utils._data_at_dim_vals(data, dim_arr, dim_idx, vals)
+3×2 view(::Matrix{Int64}, :, [1, 3]) with eltype Int64:
+ 1  3
+ 4  6
+ 7  9
+```
+"""
+function _data_at_dim_vals(data, dim_arr, dim_idx, vals)
+    nearest_indices = map(val -> nearest_index(dim_arr, val), vals)
+    return selectdim(data, dim_idx, nearest_indices)
+end
+
 end

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -34,7 +34,8 @@ export OutputVar,
     convert_units,
     integrate_lonlat,
     integrate_lon,
-    integrate_lat
+    integrate_lat,
+    isempty
 
 """
     Representing an output variable
@@ -300,6 +301,20 @@ function is_z_1D(var::OutputVar)
     has_altitude(var) || error("Variable does not have an altitude dimension")
 
     return length(size(altitudes(var))) == 1
+end
+
+"""
+    isempty(var::OutputVar)
+
+Determine whether an OutputVar is empty.
+"""
+function Base.isempty(var::OutputVar)
+    # Do not include :interpolant because var.interpolant is Nothing if data is
+    # zero dimensional and empty and isempty(Nothing) throws an error
+    return map(
+        fieldname -> isempty(getproperty(var, fieldname)),
+        filter(x -> x != :interpolant, fieldnames(OutputVar)),
+    ) |> all
 end
 
 function Base.copy(var::OutputVar)

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -104,6 +104,36 @@ end
     @test equispaced == false
 end
 
+@testset "Date and time conversion" begin
+    reference_date = Dates.DateTime(2013, 7, 1, 12)
+    date_one_day = Dates.DateTime(2013, 7, 2, 12)
+    date_one_hour = Dates.DateTime(2013, 7, 1, 13)
+    date_one_min = Dates.DateTime(2013, 7, 1, 12, 1)
+    date_one_sec = Dates.DateTime(2013, 7, 1, 12, 0, 1)
+
+    # Test time_to_date
+    @test Utils.time_to_date(reference_date, 86400.0) == date_one_day
+    @test Utils.time_to_date(reference_date, 3600.0) == date_one_hour
+    @test Utils.time_to_date(reference_date, 60.0) == date_one_min
+    @test Utils.time_to_date(reference_date, 1.0) == date_one_sec
+
+    # Test date_to_time
+    @test Utils.date_to_time(reference_date, date_one_day) == 86400.0
+    @test Utils.date_to_time(reference_date, date_one_hour) == 3600.0
+    @test Utils.date_to_time(reference_date, date_one_min) == 60.0
+    @test Utils.date_to_time(reference_date, date_one_sec) == 1.0
+
+    # Test period_to_seconds_float
+    @test Utils.period_to_seconds_float(Dates.Millisecond(1)) == 0.001
+    @test Utils.period_to_seconds_float(Dates.Second(1)) == 1.0
+    @test Utils.period_to_seconds_float(Dates.Minute(1)) == 60.0
+    @test Utils.period_to_seconds_float(Dates.Hour(1)) == 3600.0
+    @test Utils.period_to_seconds_float(Dates.Day(1)) == 86400.0
+    @test Utils.period_to_seconds_float(Dates.Week(1)) == 604800.0
+    @test Utils.period_to_seconds_float(Dates.Month(1)) == 2.629746e6
+    @test Utils.period_to_seconds_float(Dates.Year(1)) == 3.1556952e7
+end
+
 @testset "data_at_dim_vals" begin
     data = [[1, 2, 3] [4, 5, 6] [7, 8, 9]]
     dim_arr = [2.0, 3.0, 4.0]

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -103,3 +103,16 @@ end
     equispaced = Utils._isequispaced([0.0, 2.0, 3.0])
     @test equispaced == false
 end
+
+@testset "data_at_dim_vals" begin
+    data = [[1, 2, 3] [4, 5, 6] [7, 8, 9]]
+    dim_arr = [2.0, 3.0, 4.0]
+    dim_idx = 2
+
+    @test Utils._data_at_dim_vals(data, dim_arr, dim_idx, []) ==
+          reshape([], 3, 0)
+    @test Utils._data_at_dim_vals(data, dim_arr, dim_idx, [2.1]) ==
+          reshape([1; 2; 3], 3, 1)
+    @test Utils._data_at_dim_vals(data, dim_arr, dim_idx, [2.1, 2.9, 4.0]) ==
+          data
+end

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -85,6 +85,26 @@ import Unitful: @u_str
     )
 end
 
+@testset "empty" begin
+    dims = OrderedDict{String, Vector{Float64}}()
+    data = Float64[]
+    empty_var = ClimaAnalysis.OutputVar(dims, data)
+    @test ClimaAnalysis.isempty(empty_var)
+
+    dims = OrderedDict{String, Vector{Float64}}()
+    data = fill(1.0)
+    empty_var = ClimaAnalysis.OutputVar(dims, data)
+    @test !ClimaAnalysis.isempty(empty_var)
+
+    long = 0.0:180.0 |> collect
+    dims = OrderedDict(["long" => long])
+    data = ones(size(long))
+    dim_attributes = OrderedDict(["lon" => Dict("b" => 2)])
+    attribs = Dict("short_name" => "bob", "long_name" => "hi")
+    not_empty_var = ClimaAnalysis.OutputVar(attribs, dims, dim_attributes, data)
+    @test !ClimaAnalysis.isempty(not_empty_var)
+end
+
 @testset "Arithmetic operations" begin
     long = 0.0:180.0 |> collect
     lat = 0.0:90.0 |> collect


### PR DESCRIPTION
Close #78 - This PR implement split_by_season for `OutputVar`s. It return four OutputVars with each one corresponding to a season. This PR also add functions for converting from date to time and time to date (Utils.time_to_date, Utils.date_to_time, Utils.period_to_seconds_float). 

This PR add a bug to the documentation which cause the documentation for `Var.split_by_season` to be `ClimaAnalysis.Utils.split_by_season` instead of `ClimaAnalysis.Var.split_by_season`. 
