### PR TITLE
Change deprecated kwarg in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -151,7 +151,7 @@ If we want to make a heatmap for `ta_max` at time of 100 s at altitude `z` of 30
 import CairoMakie
 import ClimaAnalysis.Visualize as viz
 
-fig = Makie.Figure(resolution = (400, 600))
+fig = Makie.Figure(size = (400, 600))
 
 viz.plot!(
   fig,


### PR DESCRIPTION
Quick Start docs previously used a deprecated kwarg in the visualize section. The deprecated kwarg, `resolution`, is swapped for `shape`.  The line no longer throws a warning after the change

<!--- THESE LINES ARE COMMENTED -->
## Purpose 


Closes #77 -- this will automatically close issue 77 on PR merge



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content

- Changed line in docs to no longer use deprecated kwarg



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
