### PR TITLE
Fix bug and change multiplication and division to be elementwise for OutputVars

### DIFF
--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1007,36 +1007,52 @@ macro overload_binary_op(op)
             )
         end
         function Base.$op(x::OutputVar, y::Real)
-            ret_var = copy(x)
-            @. ret_var.data = $op(x.data, y)
-            empty!(ret_var.attributes)
+            ret_attributes = empty(x.attributes)
 
             specific_attributes = ("short_name", "long_name")
 
             for attr in specific_attributes
                 if haskey(x.attributes, attr)
-                    ret_var.attributes[attr] =
+                    ret_attributes[attr] =
                         string(x.attributes[attr], " ", string($op), " ", y)
                 end
             end
 
-            return ret_var
+            ret_dims = deepcopy(x.dims)
+            ret_dim_attributes = deepcopy(x.dim_attributes)
+
+            ret_data = @. $op(x.data, y)
+
+            return OutputVar(
+                ret_attributes,
+                ret_dims,
+                ret_dim_attributes,
+                ret_data,
+            )
         end
         function Base.$op(x::Real, y::OutputVar)
-            ret_var = copy(y)
-            @. ret_var.data = $op(x, y.data)
-            empty!(ret_var.attributes)
+            ret_attributes = empty(y.attributes)
 
             specific_attributes = ("short_name", "long_name")
 
             for attr in specific_attributes
                 if haskey(y.attributes, attr)
-                    ret_var.attributes[attr] =
+                    ret_attributes[attr] =
                         string(x, " ", string($op), " ", y.attributes[attr])
                 end
             end
 
-            return ret_var
+            ret_dims = deepcopy(y.dims)
+            ret_dim_attributes = deepcopy(y.dim_attributes)
+
+            ret_data = @. $op(x, y.data)
+
+            return OutputVar(
+                ret_attributes,
+                ret_dims,
+                ret_dim_attributes,
+                ret_data,
+            )
         end
     end
 end

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -997,7 +997,7 @@ macro overload_binary_op(op)
             ret_dims = x.dims
             ret_dim_attributes = x.dim_attributes
 
-            ret_data = $op(x.data, y.data)
+            ret_data = @. $op(x.data, y.data)
 
             return OutputVar(
                 ret_attributes,

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -154,6 +154,13 @@ end
     @test var1plusvar3.data == data1 .+ data3
     @test ClimaAnalysis.short_name(var1plusvar3) == "bob + bula"
     @test ClimaAnalysis.long_name(var1plusvar3) == "hi + bob"
+
+    # Test for element wise multiplication and division between OutputVars
+    var_times = var1 * var3
+    @test var_times.data == var1.data .* var3.data
+
+    var_divide = var1 / var3
+    @test var_divide.data == var1.data ./ var3.data
 end
 
 @testset "Reductions (sphere dims)" begin

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -142,12 +142,14 @@ end
     @test var1plus10.data == data1 .+ 10
     @test ClimaAnalysis.short_name(var1plus10) == "bob + 10"
     @test ClimaAnalysis.long_name(var1plus10) == "hi + 10"
+    @test var1plus10((0.0, 0.0, 0.0)) == var1((0.0, 0.0, 0.0)) + 10
 
     tenplusvar1 = 10 + var1
 
     @test tenplusvar1.data == data1 .+ 10
     @test ClimaAnalysis.short_name(tenplusvar1) == "10 + bob"
     @test ClimaAnalysis.long_name(tenplusvar1) == "10 + hi"
+    @test tenplusvar1((0.0, 0.0, 0.0)) == 10 + var1((0.0, 0.0, 0.0))
 
     var1plusvar3 = var1 + var3
 


### PR DESCRIPTION
Closes #81, #82 - This PR fix a bug where interpolation do not update when a binary operation is performed between an `OutputVar` and a Real and change multiplication and division between `OutputVar`s to be elementwise multiplication and division instead of matrix multiplication and division. 