### PR TITLE
Add Var.bias and Var.squared_error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -204,6 +204,55 @@ julia> [MAM.data, JJA.data, DJF.data]
  [1.0]
 ```
 
+### Bias and squared error
+Bias and squared error can be computed from simulation data and observational data in
+`OutputVar`s using `bias(sim, obs)` and `squared_error(sim, obs)`. The function `bias(sim,
+obs)` returns a `OutputVar` whose data is the bias (`sim.data - obs.data`) and computes the
+ global bias of `data` in `sim` and `obs` over longitude and latitude. The result is stored
+in `var.attributes["global_bias"]`. The function `squared_error(sim, obs)` returns a
+`OutputVar` whose data is the squared error (`(sim.data - obs.data)^2`) and computes the
+global mean squared error (MSE) and the global root mean squared error (RMSE) of `data` in
+`sim` and `obs` over longitude and latitude. The result is stored in
+`var.attributes["global_mse"]` and `var.attributes["global_rmse"]`. Resampling is
+automatically done by resampling `obs` on `sim`. If you are only interested in computing
+global bias, MSE, or RMSE, you can use `global_bias(sim, obs)`, `global_mse(sim, obs)`, or
+`global_rmse(sim, obs)`.
+
+As of now, these functions are implemented for `OutputVar`s with only the dimensions
+longitude and latitude. Furthermore, units must be supplied for data and dimensions in `sim`
+and `obs` and the units for longitude and latitude should be degrees.
+
+Consider the following example, where we compute the bias and RMSE between our simulation
+and some observations stored in "ta\_1d\_average.nc".
+
+```@julia bias_and_mse
+julia> obs_var = OutputVar("ta_1d_average.nc"); # load in observational data
+
+julia> sim_var = get(simdir("simulation_output"), "ta"); # load in simulation data
+
+julia> ClimaAnalysis.short_name(sim_var)
+"ta"
+
+julia> bias_var = ClimaAnalysis.bias(sim_var, obs_var); # bias_var is a OutputVar that can be plotted
+
+julia> global_bias(sim, obs)
+2.0
+
+julia> units(bias_var)
+"K"
+
+julia> se_var = ClimaAnalysis.squared_error(sim_var, obs_var); # can also be plotted
+
+julia> global_mse(sim, obs)
+4.0
+
+julia> global_rmse(sim, obs)
+2.0
+
+julia> units(se_var)
+"K^2"
+```
+
 ## Bug fixes
 
 - Increased the default value for `warp_string` to 72.

--- a/NEWS.md
+++ b/NEWS.md
@@ -207,6 +207,8 @@ julia> [MAM.data, JJA.data, DJF.data]
 ## Bug fixes
 
 - Increased the default value for `warp_string` to 72.
+- Binary operation between Real and OutputVar now update the interpolation of the resulting
+  OutputVar
 
 ## New compat requirements
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,6 +60,11 @@ Var.integrate_lonlat
 Var.integrate_lat
 Var.integrate_lon
 Var.split_by_season(var::OutputVar)
+Var.bias
+Var.global_bias
+Var.squared_error
+Var.global_mse
+Var.global_rmse
 ```
 
 ## Utilities

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -140,3 +140,52 @@ julia> [MAM.data, JJA.data, DJF.data]
  [3.0]
  [1.0]
 ```
+
+## Bias and squared error
+Bias and squared error can be computed from simulation data and observational data in
+`OutputVar`s using `bias(sim, obs)` and `squared_error(sim, obs)`. The function `bias(sim,
+obs)` returns a `OutputVar` whose data is the bias (`sim.data - obs.data`) and computes the
+ global bias of `data` in `sim` and `obs` over longitude and latitude. The result is stored
+in `var.attributes["global_bias"]`. The function `squared_error(sim, obs)` returns a
+`OutputVar` whose data is the squared error (`(sim.data - obs.data)^2`) and computes the
+global mean squared error (MSE) and the global root mean squared error (RMSE) of `data` in
+`sim` and `obs` over longitude and latitude. The result is stored in
+`var.attributes["global_mse"]` and `var.attributes["global_rmse"]`. Resampling is
+automatically done by resampling `obs` on `sim`. If you are only interested in computing
+global bias, MSE, or RMSE, you can use `global_bias(sim, obs)`, `global_mse(sim, obs)`, or
+`global_rmse(sim, obs)`.
+
+As of now, these functions are implemented for `OutputVar`s with only the dimensions
+longitude and latitude. Furthermore, units must be supplied for data and dimensions in `sim`
+and `obs` and the units for longitude and latitude should be degrees.
+
+Consider the following example, where we compute the bias and RMSE between our simulation
+and some observations stored in "ta\_1d\_average.nc".
+
+```@julia bias_and_mse
+julia> obs_var = OutputVar("ta_1d_average.nc"); # load in observational data
+
+julia> sim_var = get(simdir("simulation_output"), "ta"); # load in simulation data
+
+julia> ClimaAnalysis.short_name(sim_var)
+"ta"
+
+julia> bias_var = ClimaAnalysis.bias(sim_var, obs_var); # bias_var is a OutputVar that can be plotted
+
+julia> global_bias(sim, obs)
+2.0
+
+julia> units(bias_var)
+"K"
+
+julia> se_var = ClimaAnalysis.squared_error(sim_var, obs_var); # can also be plotted
+
+julia> global_mse(sim, obs)
+4.0
+
+julia> global_rmse(sim, obs)
+2.0
+
+julia> units(se_var)
+"K^2"
+```


### PR DESCRIPTION
closes #84 - This PR adds functions to compute the error between simulation and observational data.

In particular, the functions `Var.bias`, `Var.squared_error`, `Var.global_bias`, `Var.global_mse`, and `Var.global_rmse` are added.

One issue is that the unit of data in the `OutputVar` computed by `Var.squared_error` will always be a string even if the unit of the simulation and observational data is a type Unitful. This is because the string representation of something type Unitful is not always parseable as a Unitful.Unit (see: https://github.com/PainterQubits/Unitful.jl/issues/412). 
