### PR TITLE
Add Var.reordered_as

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,36 @@
 ClimaAnalysis.jl Release Notes
 ===============================
 
+v0.5.9
+------
+
+## Features
+
+### Reorder dimensions
+Before, resampling requires that the order of the dimensions is the same between the two
+`OutputVar`s. This feature adds the functionality of reordering the dimensions in a
+`OutputVar` to match the ordering of dimensions in another `OutputVar`. See the example
+below of this functionality.
+
+```julia
+julia> src_var.dims |> keys |> collect
+2-element Vector{String}:
+ "long"
+ "lat"
+
+julia> dest_var.dims |> keys |> collect
+2-element Vector{String}:
+ "lat"
+ "long"
+
+julia> reordered_var = ClimaAnalysis.reordered_as(src_var, dest_var);
+
+julia> reordered_var.dims |> keys |> collect
+2-element Vector{String}:
+ "lat"
+ "long"
+```
+
 v0.5.8
 ------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,8 @@ v0.5.9
 ### Reorder dimensions
 Before, resampling requires that the order of the dimensions is the same between the two
 `OutputVar`s. This feature adds the functionality of reordering the dimensions in a
-`OutputVar` to match the ordering of dimensions in another `OutputVar`. See the example
-below of this functionality.
+`OutputVar` to match the ordering of another `OutputVar`. The function `resampled_as` is
+updated to use `reordered_as`. See the example below of this functionality.
 
 ```julia
 julia> src_var.dims |> keys |> collect

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,8 +3,10 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 ClimaAnalysis = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 CairoMakie = "0.12.5"
 Documenter = "1"
 GeoMakie = "0.7.3"
+OrderedCollections = "1.3"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -54,6 +54,7 @@ Var.has_altitude
 Var.conventional_dim_name
 Var.dim_units
 Var.range_dim
+Var.reordered_as
 Var.resampled_as
 Var.convert_units
 Var.integrate_lonlat

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -67,6 +67,51 @@ The `Atmos` module in `ClimaAnalysis` comes with a function,
 `OutputVar` is returned where the values are linearly interpolated on fixed
 pressure levels.
 
+## How do I reorder the dimensions in a `OutputVar` to match the dimensions in another `OutputVar`?
+
+You can use the `reordered_as(src_var, dest_var)` function where `src_var` is a `OutputVar`
+with the dimensions you want to reorder to match the dimensions in the OutputVar `dest_var`.
+
+```@setup reordered_as
+import ClimaAnalysis
+import OrderedCollections: OrderedDict
+
+src_long = 0.0:180.0 |> collect
+src_lat = 0.0:90.0 |> collect
+src_data = ones(length(src_long), length(src_lat))
+src_dims = OrderedDict(["long" => src_long, "lat" => src_lat])
+src_attribs = Dict("long_name" => "hi")
+src_dim_attribs = OrderedDict([
+    "long" => Dict("units" => "test_units1"),
+    "lat" => Dict("units" => "test_units2"),
+])
+src_var =
+    ClimaAnalysis.OutputVar(src_attribs, src_dims, src_dim_attribs, src_data)
+
+dest_long = 20.0:180.0 |> collect
+dest_lat = 30.0:90.0 |> collect
+dest_data = zeros(length(dest_lat), length(dest_long))
+dest_dims = OrderedDict(["lat" => dest_lat, "long" => dest_long])
+dest_attribs = Dict("long_name" => "hi")
+dest_dim_attribs = OrderedDict([
+    "lat" => Dict("units" => "test_units4"),
+    "long" => Dict("units" => "test_units3"),
+])
+dest_var = ClimaAnalysis.OutputVar(
+    dest_attribs,
+    dest_dims,
+    dest_dim_attribs,
+    dest_data,
+)
+```
+
+```@repl reordered_as
+src_var.dims |> keys |> collect
+dest_var.dims |> keys |> collect
+reordered_var = ClimaAnalysis.reordered_as(src_var, dest_var);
+reordered_var.dims |> keys |> collect
+```
+
 ## How do I resample the data in a `OutputVar` using the dimensions from another `OutputVar`?
 
 You can use the `resampled_as(src_var, dest_var)` function where `src_var` is a

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -838,6 +838,7 @@ Resample `data` in `src_var` to `dims` in `dest_var`.
 The resampling performed here is a 1st-order linear resampling.
 """
 function resampled_as(src_var::OutputVar, dest_var::OutputVar)
+    src_var = reordered_as(src_var, dest_var)
     _check_dims_consistent(src_var, dest_var)
 
     src_resampled_data =

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -1205,35 +1205,6 @@ end
         var_missing_dim_units,
     )
 
-    # Mismatch in ordering of dims
-    lon = collect(range(-179.5, 179.5, 360))
-    lat = collect(range(-89.5, 89.5, 180))
-    data_ones = ones(length(lon), length(lat))
-    dims = OrderedDict(["lon" => lon, "lat" => lat])
-    attribs =
-        Dict("long_name" => "idk", "short_name" => "short", "units" => "kg")
-    dim_attribs = OrderedDict([
-        "lon" => Dict("units" => "deg"),
-        "lat" => Dict("units" => "deg"),
-    ])
-    var_lonlat = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data_ones)
-    lon = collect(range(-179.5, 179.5, 360))
-    lat = collect(range(-89.5, 89.5, 180))
-    data_ones = ones(length(lat), length(lon))
-    dims = OrderedDict(["lat" => lat, "lon" => lon])
-    attribs =
-        Dict("long_name" => "idk", "short_name" => "short", "units" => "kg")
-    dim_attribs = OrderedDict([
-        "lat" => Dict("units" => "deg"),
-        "lon" => Dict("units" => "deg"),
-    ])
-    var_latlon = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data_ones)
-    @test_throws ErrorException ClimaAnalysis.bias(var_lonlat, var_latlon)
-    @test_throws ErrorException ClimaAnalysis.squared_error(
-        var_lonlat,
-        var_latlon,
-    )
-
     # Missing dims
     lon = collect(range(-179.5, 179.5, 360))
     data_missing_dim = ones(length(lon))


### PR DESCRIPTION
closes #94 - This PR adds the function `reordered_as` which reorder the dimensions in a OutputVar to match the ordering of dimensions in another OutputVar. Furthermore, `resampled_as` is updated to use `reordered_as`.