### PR TITLE
Fix formatting and display of legend in box plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,8 @@ julia> reordered_var.dims |> keys |> collect
 
 - Fix models repeating in legend of box plots by not considering the models in `model_names`
   when finding the best and worst models
+- Fix legend from covering the box plot by adding the parameter `legend_text_width` which
+  control the number of characters on each line of the legend of the box plot
 
 v0.5.8
 ------

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,11 @@ julia> reordered_var.dims |> keys |> collect
  "long"
 ```
 
+## Bug fixes
+
+- Fix models repeating in legend of box plots by not considering the models in `model_names`
+  when finding the best and worst models
+
 v0.5.8
 ------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@ julia> reordered_var.dims |> keys |> collect
   when finding the best and worst models
 - Fix legend from covering the box plot by adding the parameter `legend_text_width` which
   control the number of characters on each line of the legend of the box plot
+- Use default marker size instead of a marker size of 20 when plotting other models beside
+  `CliMA` on the box plot
 
 v0.5.8
 ------

--- a/docs/src/visualize_rmse_var.md
+++ b/docs/src/visualize_rmse_var.md
@@ -4,10 +4,11 @@ Instead of computing summary statistics, it may be more helpful to plot a box pl
 heatmap. `ClimaAnalysis` provides the functions `plot_boxplot!` and `plot_leaderboard!`
 to help visualize the root mean squared errors (RMSEs) in a `RMSEVariable`.
 
-The function [`Visualize.plot_boxplot!`](@ref) makes a box plot for each
-category in the `RMSEVariable`. The best model and worst model and any other models in
-`model_names` are plotted. The category to find the best and worst model defaults to
-"ANN", but can be changed using the parameter `best_and_worst_category_name`.
+The function [`Visualize.plot_boxplot!`](@ref) makes a box plot for each category in the
+`RMSEVariable`. The best model and worst model and any other models in `model_names` are
+plotted. When finding the best and worst single models, any models in `model_names` will be
+excluded. The category to find the best and worst model defaults to "ANN", but can be
+changed using the parameter `best_and_worst_category_name`.
 
 The function [`Visualize.plot_leaderboard!`](@ref) makes a heatmap of the
 RMSEs between the variables of interest and the categories. The best model for each variable

--- a/ext/ClimaAnalysisMakieExt.jl
+++ b/ext/ClimaAnalysisMakieExt.jl
@@ -640,7 +640,8 @@ end
 Plot a Tukey style boxplot for each category in `rmse_var`.
 
 The best and worst single models are found for the category `best_and_worst_category_name`
-and are plotted on the boxplot. Additionally, any model in `model_names` will also be
+and are plotted on the boxplot. When finding the best and worst single models, any models in
+`model_names` will be excluded. Additionally, any model in `model_names` will also be
 plotted on the boxplot.
 
 The parameter `ploc` determines where to place the plot on the figure.
@@ -693,15 +694,19 @@ function Visualize.plot_boxplot!(
         whiskerlinewidth = 1,
     )
 
-    # Plotting best and worst model
+    # Delete any model in model_names to exclude them when finding best and worst models
+    rmse_var_delete =
+        ClimaAnalysis.Leaderboard._delete_model(rmse_var, model_names...)
+
+    # Find and plot best and worst models
     absolute_worst_values, absolute_worst_model_name =
         ClimaAnalysis.find_worst_single_model(
-            rmse_var,
+            rmse_var_delete,
             category_name = best_and_worst_category_name,
         )
     absolute_best_values, absolute_best_model_name =
         ClimaAnalysis.find_best_single_model(
-            rmse_var,
+            rmse_var_delete,
             category_name = best_and_worst_category_name,
         )
     Makie.scatter!(

--- a/ext/ClimaAnalysisMakieExt.jl
+++ b/ext/ClimaAnalysisMakieExt.jl
@@ -763,7 +763,6 @@ function Visualize.plot_boxplot!(
                 1:num_cats,
                 rmse_var[model_name],
                 label = model_name,
-                markersize = 20,
                 color = :red,
             ) |> pt -> push!(pts_on_boxplot, pt)
         end

--- a/src/Leaderboard.jl
+++ b/src/Leaderboard.jl
@@ -483,6 +483,36 @@ function add_model(rmse_var::RMSEVariable, models::String...)
 end
 
 """
+    _delete_model(rmse_var::RMSEVariable, models::String...)
+
+Delete one or more models named `models` from `rmse_var`.
+"""
+function _delete_model(rmse_var::RMSEVariable, models::String...)
+    # Delete model name
+    mdl_names = model_names(rmse_var)
+    num_rows = length(mdl_names)
+    setdiff!(mdl_names, models)
+
+    # Delete model
+    rmses = rmse_var.RMSEs |> copy
+    indices_to_delete = (rmse_var.model2index[model] for model in models)
+    rmses = rmse_var.RMSEs[setdiff(1:num_rows, indices_to_delete), :]
+
+    # Delete unit for model
+    units = rmse_var.units |> deepcopy
+    for name in models
+        delete!(units, name)
+    end
+    return RMSEVariable(
+        rmse_var.short_name,
+        mdl_names,
+        category_names(rmse_var),
+        rmses,
+        units,
+    )
+end
+
+"""
     _model_name_check(rmse_var::RMSEVariable, model_name)
 
 Check if `model_name` is present in the model names of `rmse_var`.

--- a/test/test_MakieExt.jl
+++ b/test/test_MakieExt.jl
@@ -191,6 +191,22 @@ using OrderedCollections
         ),
     )
     rmse_var[2, 5] = 4.0
+
+    rmse_var1 = ClimaAnalysis.read_rmses(csv_file_path, "ta")
+    rmse_var1 = ClimaAnalysis.add_model(rmse_var1, "CliMA", "test_model")
+    rmse_var1["CliMA", :] = [12.0, 12.0, 11.0, 14.0, 6.0]
+    rmse_var1["test_model", :] = [12.0, 12.0, 11.0, 14.0, 6.0]
+    ClimaAnalysis.add_unit!(
+        rmse_var1,
+        Dict(
+            "ACCESS-ESM1-5" => "units",
+            "ACCESS-CM2" => "units",
+            "CliMA" => "units",
+            "test_model" => "units",
+        ),
+    )
+    rmse_var1[2, 5] = 4.0
+
     fig = Makie.Figure(; size = (800, 300 * 3 + 400), fontsize = 20)
     ClimaAnalysis.Visualize.plot_boxplot!(
         fig,
@@ -207,7 +223,7 @@ using OrderedCollections
     )
     ClimaAnalysis.Visualize.plot_boxplot!(
         fig,
-        rmse_var,
+        rmse_var1,
         model_names = ["CliMA", "ACCESS-ESM1-5"],
         ploc = (3, 1),
         best_and_worst_category_name = "ANN",
@@ -331,6 +347,31 @@ using OrderedCollections
         best_category_name = "ANN",
     )
     output_name = joinpath(tmp_dir, "test_leaderboard_nan.png")
+    Makie.save(output_name, fig)
+
+    # Testing with long name
+    rmse_var = ClimaAnalysis.read_rmses(csv_file_path, "ta")
+    rmse_var = ClimaAnalysis.add_model(
+        rmse_var,
+        "long_name_name_name_name_name_name_name",
+    )
+    ClimaAnalysis.add_unit!(
+        rmse_var,
+        Dict(
+            "ACCESS-ESM1-5" => "units",
+            "ACCESS-CM2" => "units",
+            "long_name_name_name_name_name_name_name" => "units",
+        ),
+    )
+    rmse_var[2, 5] = 10.0
+    fig = Makie.Figure(; fontsize = 20)
+    ClimaAnalysis.Visualize.plot_boxplot!(
+        fig,
+        rmse_var,
+        model_names = ["long_name_name_name_name_name_name_name"],
+        best_and_worst_category_name = "ANN",
+    )
+    output_name = joinpath(tmp_dir, "test_boxplot_long_name.png")
     Makie.save(output_name, fig)
 
     # Test error handling for plot_leaderboard


### PR DESCRIPTION
closes #97 - This PR fixes the bugs when the legend can cover the box plot if the model names are too long and models appearing more than once in the legend. 

A new parameter called `legend_text_width` is added to `Visualize.plot_boxplot!` which control the number of characters on each line. This can be used to prevent the legend from covering parts of the box plot. Also, when computing the best and worst model, any models in `model_names` will not be used in the computation. Finally, the marker size is updated to use the default value rather than 20 when plotting other models beside "CliMA".
![test_boxplot_long_name](https://github.com/user-attachments/assets/e162985f-71fb-4f27-ace1-7914d2351270)
Note that the red point do not appear on the plot because the RMSEs are all NaNs for that model. 
