### PR TITLE
Fix empty units and bump to 0.5.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ julia> reordered_var.dims |> keys |> collect
   control the number of characters on each line of the legend of the box plot
 - Use default marker size instead of a marker size of 20 when plotting other models beside
   `CliMA` on the box plot
+- Fix support for `""` in units.
 
 v0.5.8
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAnalysis"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
-version = "0.5.8"
+version = "0.5.9"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/ext/ClimaAnalysisUnitfulExt.jl
+++ b/ext/ClimaAnalysisUnitfulExt.jl
@@ -15,6 +15,10 @@ Try converting `value` to a `Uniftul` object. If unsuccessful, just return it.
 """
 function Var._maybe_convert_to_unitful(value)
     value isa Unitful.Units && return value
+    # "" cannot be parsed but returns a wrong error (MethodError on lookup_units),
+    # so we handle it manually
+    value == "" && return value
+
     # This function in inherently type-unstable
     try
         return Unitful.uparse(value)

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -784,6 +784,13 @@ end
         data,
     )
 
+    var_empty_unit = ClimaAnalysis.OutputVar(
+        Dict{String, Any}("units" => ""),
+        Dict("long" => long),
+        dim_attributes,
+        data,
+    )
+
     @test ClimaAnalysis.has_units(var_with_unitful)
 
     # Convert to cm/s


### PR DESCRIPTION
When units are "", Unitful doesn't know what to and fails. It doesn't
fail normally, instead, it fails with a `MethodError`. This commit
treats that case specially.