### PR TITLE
Add Var._make_interpolant and boundary conditions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,16 @@ the units or units are missing.
 new_var = ClimaAnalysis.set_units(var, "kg m s^-1")
 ```
 
+### Extrapolating `OutputVar` on longitude and latitude
+Extrapolation is now possible for the longitude and latitude dimensions. If the dimension
+arrays are equispaced and span the entire range, then a periodic boundary condition is added
+for the longitude dimension and a flat boundary condition is added for the latitude
+dimension.
+
+## Bug fixes
+
+- Interpolation is not possible with dates. When dates are detected in any dimension, an
+  interpolat will not be made.
 
 v0.5.9
 ------

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -63,6 +63,23 @@ new_var = ClimaAnalysis.set_units(var, "kg m s^-1")
 !!! warning "Override existing units"
     If units already exist, this will override the units for data in `var`.
 
+## Interpolations and extrapolations
+
+Interpolating a `OutputVar` onto coordinates can be done by doing the following:
+```julia
+var((0.0, 0.0)) # var is a two-dimensional OutputVar
+```
+
+A multilinear interpolation is used to determine the value at the coordinate (0, 0).
+!!! warning "Interpolate on dates"
+    If any of the dimensions contains `Dates.DateTime` elements, interpolation is not
+    possible. `Interpolations.jl` does not support interpolating on dates.
+
+Extrapolating is supported only on the longitude and latitude dimensions. For the longitude
+and latitude dimensions, a periodic boundary condition and a flat boundary condition are
+added, respectively, when the dimension array is equispaced and spans the entire range. For
+all other cases, extrapolating beyond the domain of the dimension will throw an error.
+
 ## Integration
 
 `OutputVar`s can be integrated with respect to longitude, latitude, or both using


### PR DESCRIPTION
closes #95 and closes #99 - This PR refactors the code for making interpolations into a separate function called Var._make_interpolant. Furthermore, boundary conditions are added when appropriate for the longitude and latitude dimensions. A periodic boundary condition is added for the longitude dimension and a flat periodic boundary condition is added for the latitude dimension when the dimension array is equispaced and spans the entire range. Lastly, no interpolation will be made when the element type of any dimension array is `Dates.DateTime`. This is because Interpolations.jl do not support interpolating on dates.
