### PR TITLE
Correctly idenfity variables with `_` in the name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,9 @@ dimension.
 
 - Interpolation is not possible with dates. When dates are detected in any dimension, an
   interpolat will not be made.
+- Fix identifying variables with underscore in the short name (such as
+  `net_toa_flux`). ([#109](https://github.com/CliMA/ClimaAnalysis.jl/pull/109
+  "PR109"))
 
 v0.5.9
 ------
@@ -58,11 +61,11 @@ julia> reordered_var.dims |> keys |> collect
 ## Bug fixes
 
 - Fix models repeating in legend of box plots by not considering the models in `model_names`
-  when finding the best and worst models
+  when finding the best and worst models.
 - Fix legend from covering the box plot by adding the parameter `legend_text_width` which
-  control the number of characters on each line of the legend of the box plot
+  control the number of characters on each line of the legend of the box plot.
 - Use default marker size instead of a marker size of 20 when plotting other models beside
-  `CliMA` on the box plot
+  `CliMA` on the box plot.
 - Fix support for `""` in units.
 
 v0.5.8

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -9,11 +9,20 @@ import Dates
     @test Utils.match_nc_filename("ta_1d_average.nc") ==
           Tuple(["ta", "1d", "average"])
 
-    @test Utils.match_nc_filename("ta_1m_40s_inst.nc") ==
-          Tuple(["ta", "1m_40s", "inst"])
+    @test Utils.match_nc_filename("ta_3.0h_average.nc") ==
+          Tuple(["ta", "3.0h", "average"])
 
-    @test Utils.match_nc_filename("pfull_6.0min_max.nc") ==
-          Tuple(["pfull", "6.0min", "max"])
+    @test Utils.match_nc_filename("toa_net_flux_1m_40s_inst.nc") ==
+          Tuple(["toa_net_flux", "1m_40s", "inst"])
+
+    @test Utils.match_nc_filename("toa_net_flux_1M_inst.nc") ==
+          Tuple(["toa_net_flux", "1M", "inst"])
+
+    @test Utils.match_nc_filename("p500_1M_inst.nc") ==
+          Tuple(["p500", "1M", "inst"])
+
+    @test Utils.match_nc_filename("pfull_6.0m_max.nc") ==
+          Tuple(["pfull", "6.0m", "max"])
 
     @test Utils.match_nc_filename("hu_inst.nc") ==
           Tuple(["hu", nothing, "inst"])


### PR DESCRIPTION
The regular expression used by ClimaAnalysis was not identifying correctly variables with an underscore in the short name. The reason for this was that the time interval capturing group was too greedy. I changed the capturing group to only match with `m|M|d|y|s|h`, allowing me to capture more general short names.

Closes #110

