### PR TITLE
GeoMakie ext: no shading by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ pfull_var = ClimaAnalysis.get(simdir, short_name = "pfull", reduction = "2.0d", 
 - `Var.shift_to_start_of_previous_month` now checks for duplicate dates and throws an error
 if duplicate dates are detected.
 - Fix issue with plotting multiple figures at the same time.
+- Improve shading for `Visualize.heatmap2D_on_globe!`.
 
 v0.5.10
 -------

--- a/ext/ClimaAnalysisGeoMakieExt.jl
+++ b/ext/ClimaAnalysisGeoMakieExt.jl
@@ -357,14 +357,8 @@ function Visualize.plot_bias_on_globe!(
         ),
         :cb => Dict(:ticks => ticks),
     )
-
-    # Function for recursively merging two dictionaries if the values of the dictionaries
-    # are dictionaries and the values of those are also dictionaries and so on
-    # See: https://discourse.julialang.org/t/multi-layer-dict-merge/27261/6
-    recursive_merge(x::AbstractDict...) = merge(recursive_merge, x...)
-    recursive_merge(x...) = x[end]
-    default_and_more_kwargs = recursive_merge(default_kwargs, more_kwargs)
-
+    default_and_more_kwargs =
+        ClimaAnalysis.Utils._recursive_merge(default_kwargs, more_kwargs)
     return Visualize.contour2D_on_globe!(
         place,
         bias_var;

--- a/ext/ClimaAnalysisGeoMakieExt.jl
+++ b/ext/ClimaAnalysisGeoMakieExt.jl
@@ -163,6 +163,9 @@ function Visualize.heatmap2D_on_globe!(
         :mask => Dict(),
     ),
 )
+    default_kwargs = Dict(:plot => Dict(:shading => Makie.NoShading))
+    default_and_more_kwargs =
+        ClimaAnalysis.Utils._recursive_merge(default_kwargs, more_kwargs)
     return _geomakie_plot_on_globe!(
         place,
         var;
@@ -170,7 +173,7 @@ function Visualize.heatmap2D_on_globe!(
         plot_coastline,
         plot_colorbar,
         mask,
-        more_kwargs,
+        more_kwargs = default_and_more_kwargs,
         plot_fn = Makie.surface!,
     )
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -459,4 +459,17 @@ function _data_at_dim_vals(data, dim_arr, dim_idx, vals)
     return selectdim(data, dim_idx, nearest_indices)
 end
 
+"""
+    _recursive_merge(x::AbstractDict...)
+
+Recursively merge nested dictionaries together. In the case of keys duplicated among the
+arguments, the rightmost argument that owns the key gets its value stored in the result.
+
+The function is helpful when dealing with keyword arguments when plotting and you want to
+have default keyword arguments.
+
+See: https://discourse.julialang.org/t/multi-layer-dict-merge/27261/6
+"""
+_recursive_merge(x::AbstractDict...) = merge(_recursive_merge, x...)
+_recursive_merge(x...) = x[end]
 end

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -155,3 +155,46 @@ end
     @test Utils._data_at_dim_vals(data, dim_arr, dim_idx, [2.1, 2.9, 4.0]) ==
           data
 end
+
+@testset "Recursive merge" begin
+    dict1 = Dict("a" => 2)
+    dict2 = Dict("b" => 3)
+    @test Utils._recursive_merge(dict1, dict2) == Dict("a" => 2, "b" => 3)
+
+    dict1 = Dict("a" => 2)
+    dict2 = Dict("a" => 3)
+    @test Utils._recursive_merge(dict1, dict2) == Dict("a" => 3)
+
+    dict1 = Dict("a" => Dict("a" => 3))
+    dict2 = Dict("a" => Dict("b" => 4))
+    @test Utils._recursive_merge(dict1, dict2) ==
+          Dict("a" => Dict("a" => 3, "b" => 4))
+
+    dict1 = Dict("a" => Dict("a" => 3))
+    dict2 = Dict("a" => Dict("a" => 4))
+    @test Utils._recursive_merge(dict1, dict2) == Dict("a" => Dict("a" => 4))
+
+    dict1 = Dict("a" => Dict("a" => 3))
+    dict2 = Dict("a" => Dict("a" => 4))
+    @test Utils._recursive_merge(dict1, dict2) == Dict("a" => Dict("a" => 4))
+
+    dict1 = Dict(
+        "a" => Dict("b" => Dict("c" => 5)),
+        "b" => Dict("c" => 3),
+        "c" => 4,
+        "d" => 7,
+    )
+    dict2 = Dict(
+        "a" => Dict("b" => Dict("c" => 8)),
+        "b" => Dict("c" => 4),
+        "c" => 5,
+        "e" => 8,
+    )
+    @test Utils._recursive_merge(dict1, dict2) == Dict(
+        "a" => Dict("b" => Dict("c" => 8)),
+        "b" => Dict("c" => 4),
+        "c" => 5,
+        "d" => 7,
+        "e" => 8,
+    )
+end


### PR DESCRIPTION
GeoMakie extension `heatmap2D_on_globe!()` did not specify the default shading, therefore it had shading (Makie default), which made plots where obscured in some regions, making it difficult to clearly visualize colors. This commit fixes this issue by changing the default shading to noshading.

Before:
![myfigure_default](https://github.com/user-attachments/assets/636d6a34-433f-4016-987c-7fba50dbee34)

After:
![myfigure](https://github.com/user-attachments/assets/c7c248bb-e86d-45da-a953-831dbaa0b9ce)
 
Note that in some instances the shading was only at certain locations, making it even more confusing:
![Screenshot 2024-10-10 at 12 18 10 PM](https://github.com/user-attachments/assets/52eb5a12-34e6-414c-9bca-afac6146f5a5)
