### PR TITLE
Add error handling for duplicate dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@ var_no_ocean = ClimaAnalysis.apply_oceanmask(var)
 
 ## Bug fixes
 - Masking now affects the colorbar.
+- `Var.shift_to_start_of_previous_month` now checks for duplicate dates and throws an error
+if duplicate dates are detected.
 
 v0.5.10
 -------

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1451,6 +1451,12 @@ function shift_to_start_of_previous_month(var::OutputVar)
     date_arr .=
         date_arr .|> Dates.firstdayofmonth .|> date -> date - Dates.Month(1)
 
+    # Check for duplicate dates
+    unique_dates = unique(date_arr)
+    unique_dates != date_arr && error(
+        "Dates are not unique after applying shift_to_start_of_previous_month",
+    )
+
     # Convert from dates to seconds
     start_date = date_arr[begin]
     time_arr = map(date -> date_to_time(start_date, date), date_arr)

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -1505,6 +1505,23 @@ end
     @test_throws ErrorException ClimaAnalysis.shift_to_start_of_previous_month(
         var_min,
     )
+
+    # Duplicate dates after applying transformations
+    time_arr = [
+        Dates.DateTime("2010-01-02T00:00:00"),
+        Dates.DateTime("2010-01-21T00:00:00"),
+        Dates.DateTime("2010-01-31T00:00:00"),
+    ]
+    data = ones(length(time_arr))
+    dims = OrderedDict("time" => time_arr)
+    dim_attribs = OrderedDict("time" => Dict("blah" => "blah"))
+    attribs =
+        Dict("long_name" => "idk", "short_name" => "short", "units" => "kg")
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+    var_s = ClimaAnalysis.Var._dates_to_seconds(var)
+    @test_throws ErrorException ClimaAnalysis.shift_to_start_of_previous_month(
+        var_s,
+    )
 end
 
 @testset "Land and ocean masks" begin


### PR DESCRIPTION
closes #116  - Before, the function Var.shift_to_start_of_previous_month does not has error handling for duplicate dates.
 This PR adds a check for duplicate dates and throws an error if there are duplicate dates. 