### PR TITLE
Fix bug with plotting multiple figures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ var_no_ocean = ClimaAnalysis.apply_oceanmask(var)
 - Masking now affects the colorbar.
 - `Var.shift_to_start_of_previous_month` now checks for duplicate dates and throws an error
 if duplicate dates are detected.
+- Fix issue with plotting multiple figures at the same time.
 
 v0.5.10
 -------

--- a/ext/ClimaAnalysisGeoMakieExt.jl
+++ b/ext/ClimaAnalysisGeoMakieExt.jl
@@ -84,11 +84,11 @@ function _geomakie_plot_on_globe!(
 
     title = get(axis_kwargs, :title, var.attributes["long_name"])
 
-    GeoMakie.GeoAxis(place[p_loc...]; title, axis_kwargs...)
+    ax = GeoMakie.GeoAxis(place[p_loc...]; title, axis_kwargs...)
 
-    plot = plot_fn(lon, lat, var.data; plot_kwargs...)
-    plot_mask && Makie.poly!(mask; mask_kwargs...)
-    plot_coastline && Makie.lines!(GeoMakie.coastlines(); coast_kwargs...)
+    plot = plot_fn(ax, lon, lat, var.data; plot_kwargs...)
+    plot_mask && Makie.poly!(ax, mask; mask_kwargs...)
+    plot_coastline && Makie.lines!(ax, GeoMakie.coastlines(); coast_kwargs...)
 
     if plot_colorbar
         p_loc_cb = Tuple([p_loc[1], p_loc[2] + 1])

--- a/ext/ClimaAnalysisMakieExt.jl
+++ b/ext/ClimaAnalysisMakieExt.jl
@@ -79,9 +79,9 @@ function Visualize.heatmap2D!(
         axis_kwargs = pairs(axis_kwargs_dict)
     end
 
-    Makie.Axis(place[p_loc...]; title, xlabel, ylabel, axis_kwargs...)
+    ax = Makie.Axis(place[p_loc...]; title, xlabel, ylabel, axis_kwargs...)
 
-    plot = Makie.heatmap!(dim1, dim2, var.data; plot_kwargs...)
+    plot = Makie.heatmap!(ax, dim1, dim2, var.data; plot_kwargs...)
 
     p_loc_cb = Tuple([p_loc[1], p_loc[2] + 1])
     Makie.Colorbar(
@@ -318,8 +318,8 @@ function Visualize.line_plot1D!(
         axis_kwargs = pairs(axis_kwargs_dict)
     end
 
-    Makie.Axis(place[p_loc...]; title, xlabel, ylabel, axis_kwargs...)
-    Makie.lines!(x, y; plot_kwargs...)
+    ax = Makie.Axis(place[p_loc...]; title, xlabel, ylabel, axis_kwargs...)
+    Makie.lines!(ax, x, y; plot_kwargs...)
 end
 
 """

--- a/test/test_GeoMakieExt.jl
+++ b/test/test_GeoMakieExt.jl
@@ -27,7 +27,10 @@ using OrderedCollections
     ])
     var2D = ClimaAnalysis.OutputVar(attribs, dims2D, dim_attributes2D, data2D)
 
+    # Intialize another figure to see if plotting with multiple figures initialized is
+    # possible
     fig = Makie.Figure()
+    fig1 = Makie.Figure()
 
     ClimaAnalysis.Visualize.heatmap2D_on_globe!(fig, var2D)
 

--- a/test/test_MakieExt.jl
+++ b/test/test_MakieExt.jl
@@ -29,7 +29,10 @@ using OrderedCollections
     ])
     var3D = ClimaAnalysis.OutputVar(attribs, dims3D, dim_attributes3D, data3D)
 
+    # Intialize another figure to see if plotting with multiple figures initialized is
+    # possible
     fig = Makie.Figure()
+    fig1 = Makie.Figure()
     @test_throws ErrorException ClimaAnalysis.Visualize.heatmap2D!(fig, var3D)
 
     data2D = reshape(1.0:(91 * 181), (181, 91))
@@ -91,7 +94,10 @@ using OrderedCollections
     dim_attributes1D = OrderedDict(["lat" => Dict(["units" => "degrees"])])
     var1D = ClimaAnalysis.OutputVar(attribs, dims1D, dim_attributes1D, data1D)
 
+    # Intialize another figure to see if plotting with multiple figures initialized is
+    # possible
     fig = Makie.Figure()
+    fig2 = Makie.Figure()
     ClimaAnalysis.Visualize.line_plot1D!(fig, var1D)
     output_name = joinpath(tmp_dir, "test1D.png")
     Makie.save(output_name, fig)


### PR DESCRIPTION
closes #112 - For the functions `_geomakie_plot_on_globe!`, `heatmap2D!`, and `line_plot1D!`, you cannot initialize multiple figures and use these functions afterward as you get the error "LoadError: There is no current axis to plot into". To fix this, we initialize an `Axis` object in the function and use that for plotting.