### PR TITLE
Add Var.replace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,14 @@ ts_max_var = ClimaAnalysis.get(simdir, short_name = "ts", reduction = "max", per
 pfull_var = ClimaAnalysis.get(simdir, short_name = "pfull", reduction = "2.0d", period = "inst")
 ```
 
+### Replace values in data of a `OutputVar`
+When dealing with land or ocean data, there can potentially be `missing` or `NaN` values in
+the data. The function `replace` can be used to replace `missing` or `NaN` values in
+`Var.data` with another value like 0.0. See the example below of this usage.
+```julia
+ClimaAnalysis.replace(var, NaN => 0.0, missing => 0.0)
+```
+
 ## Bug fixes
 - Masking now affects the colorbar.
 - `Var.shift_to_start_of_previous_month` now checks for duplicate dates and throws an error

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -70,6 +70,7 @@ Var.global_rmse
 Var.shift_to_start_of_previous_month
 Var.apply_landmask
 Var.apply_oceanmask
+Base.replace(var::OutputVar, old_new::Pair...)
 ```
 
 ## Leaderboard

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -164,3 +164,12 @@ data of `var`, where any coordinate corresponding to ocean is zero.
 var_no_land = ClimaAnalysis.apply_landmask(var)
 var_no_ocean = ClimaAnalysis.apply_oceanmask(var)
 ```
+
+## How do I replace `NaN` and `missing` values in the data of a `OutputVar` with 0.0?
+
+You can use `replace` to replace all `NaN` and `missing` values in the  data of a
+`OutputVar` with 0.0. See the example below of this usage.
+
+```julia
+var_no_nan_and_missing = ClimaAnalysis.replace(var, missing => 0.0, NaN => 0.0)
+```

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -55,7 +55,8 @@ export OutputVar,
     set_units,
     shift_to_start_of_previous_month,
     apply_landmask,
-    apply_oceanmask
+    apply_oceanmask,
+    replace
 
 """
     Representing an output variable
@@ -1652,6 +1653,26 @@ function _apply_lonlat_mask(var, mask::AbstractString)
     ret_dims = deepcopy(var.dims)
     ret_dim_attributes = deepcopy(var.dim_attributes)
     return OutputVar(ret_attribs, ret_dims, ret_dim_attributes, masked_data)
+end
+
+"""
+    replace(var::OutputVar, old_new::Pair...)
+
+Return a `OutputVar` where, for each pair `old  => new`, all occurences of `old` are
+replaced by `new` in `Var.data`
+
+This function is useful if there are `NaN`s or `missing` values in the data. For instance,
+you want to use the ocean mask, but there are `NaN`s in the ocean. You can replace all the
+`NaN` and `missing` values with 0.0 and apply the ocean mask afterward.
+"""
+function Base.replace(var::OutputVar, old_new::Pair...)
+    replaced_data = replace(var.data, old_new...)
+
+    # Remake OutputVar with replaced_data
+    ret_attribs = deepcopy(var.attributes)
+    ret_dims = deepcopy(var.dims)
+    ret_dim_attributes = deepcopy(var.dim_attributes)
+    return OutputVar(ret_attribs, ret_dims, ret_dim_attributes, replaced_data)
 end
 
 """


### PR DESCRIPTION
closes #123; This PR adds `Var.replace` which can be used to replace all `missing` and `NaN` values in `data` with another value. This use case for this function is dealing with land/ocean simulations where values in the ocean/land are `missing` and `NaN` values.