### PR TITLE
Fix duplicate values on colorbar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,7 +70,8 @@ if duplicate dates are detected.
 - Fix issue with plotting multiple figures at the same time.
 - Improve shading for `Visualize.heatmap2D_on_globe!`.
 - Add support for automatically converting CFTime.AbstractCFDateTime dates to seconds.
-- Treat `NaN`s as zeros when integrating (`integrate_lon, integrate_lat, integrate_lonlat`)
+- Treat `NaN`s as zeros when integrating (`integrate_lon, integrate_lat, integrate_lonlat`).
+- Fix duplicate values on colorbar for plotting bias.
 
 v0.5.10
 -------

--- a/ext/ClimaAnalysisGeoMakieExt.jl
+++ b/ext/ClimaAnalysisGeoMakieExt.jl
@@ -348,7 +348,13 @@ function Visualize.plot_bias_on_globe!(
     levels = collect(range(min_level, max_level, length = nlevels))
     offset = levels[argmin(abs.(levels))]
     levels = levels .- offset
-    ticklabels = map(x -> string(round(x; digits = 0)), levels)
+    # log(0.1, 0.1 * (max_level - min_level)) computes the number of digits we need to round
+    # to (e.g. if the difference is 0.1, the digits we need to round to is 2 and if the
+    # difference is 0.01, then the digits we need to round to is 3)
+    # Take the maximum with 0 because log(0.1, 0.1 * (max_level - min_level)) is negative
+    # when the difference is greater than or equal to 100
+    digits_to_round = max(0, ceil(Int, log(0.1, 0.1 * (max_level - min_level))))
+    ticklabels = map(x -> string(round(x; digits = digits_to_round)), levels)
     ticks = (levels, ticklabels)
 
     default_kwargs = Dict(

--- a/test/test_GeoMakieExt.jl
+++ b/test/test_GeoMakieExt.jl
@@ -122,7 +122,12 @@ using OrderedCollections
     data_zero = zeros(length(lon), length(lat))
     var_zero = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data_zero)
 
-    ClimaAnalysis.Visualize.plot_bias_on_globe!(fig6, var, var_zero)
+    ClimaAnalysis.Visualize.plot_bias_on_globe!(
+        fig6,
+        var,
+        var_zero,
+        cmap_extrema = (-0.001, 0.001),
+    )
     output_name = joinpath(tmp_dir, "plot_bias.png")
     Makie.save(output_name, fig6)
 


### PR DESCRIPTION
closes #142 - This PR fixes duplicate values on the colorbar when plotting bias. The colorbar can now be from -0.1 to 0.1 and not has duplicate values.
![plot_bias](https://github.com/user-attachments/assets/1b1cb3e0-b65d-4d3f-bc50-bea0a101e62e)
