### PR TITLE
Fix cmap_extrema when NaNs are in the data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,7 @@ if duplicate dates are detected.
 - Add support for automatically converting CFTime.AbstractCFDateTime dates to seconds.
 - Treat `NaN`s as zeros when integrating (`integrate_lon, integrate_lat, integrate_lonlat`).
 - Fix duplicate values on colorbar for plotting bias.
+- Fix `NaN`s for colorbar when plotting bias.
 
 v0.5.10
 -------

--- a/ext/ClimaAnalysisGeoMakieExt.jl
+++ b/ext/ClimaAnalysisGeoMakieExt.jl
@@ -5,6 +5,8 @@ import GeoMakie: Makie
 import ClimaAnalysis
 import ClimaAnalysis: Visualize
 
+import NaNStatistics: nanextrema
+
 MakiePlace = Union{Makie.Figure, Makie.GridLayout}
 
 """
@@ -278,7 +280,7 @@ end
     plot_bias_on_globe!(fig::Makie.Figure,
                         sim::ClimaAnalysis.OutputVar,
                         obs::ClimaAnalysis.OutputVar;
-                        cmap_extrema = extrema(ClimaAnalysis.bias(sim, obs).data),
+                        cmap_extrema = nanextrema(ClimaAnalysis.bias(sim, obs).data),
                         p_loc = (1, 1),
                         plot_coastline = true,
                         plot_colorbar = true,
@@ -287,7 +289,7 @@ end
     plot_bias_on_globe!(grid_layout::Makie.GridLayout,
                         sim::ClimaAnalysis.OutputVar,
                         obs::ClimaAnalysis.OutputVar;
-                        cmap_extrema = extrema(ClimaAnalysis.bias(sim, obs).data),
+                        cmap_extrema = nanextrema(ClimaAnalysis.bias(sim, obs).data),
                         p_loc = (1, 1),
                         plot_coastline = true,
                         plot_colorbar = true,
@@ -339,7 +341,7 @@ function Visualize.plot_bias_on_globe!(
     place::MakiePlace,
     sim::ClimaAnalysis.OutputVar,
     obs::ClimaAnalysis.OutputVar;
-    cmap_extrema = extrema(ClimaAnalysis.bias(sim, obs).data),
+    cmap_extrema = nanextrema(ClimaAnalysis.bias(sim, obs).data),
     p_loc = (1, 1),
     plot_coastline = true,
     plot_colorbar = true,

--- a/test/test_GeoMakieExt.jl
+++ b/test/test_GeoMakieExt.jl
@@ -269,8 +269,7 @@ using OrderedCollections
         var,
         var_zero,
         mask = mask_fn,
-        cmap_extrema = (-5.0, 5.0),
-        # The keyword `nan_color` do not work right now for CairoMakie.
+        # The keyword `nan_color` does not work right now for CairoMakie.
         # See https://github.com/MakieOrg/Makie.jl/issues/4524
         more_kwargs = Dict(
             :plot => ClimaAnalysis.Utils.kwargs(nan_color = :red),


### PR DESCRIPTION
closes #145 - This PR fixes cmap_extrema when `NaN`s are in the data. This is done by using `nanextrema` from `NaNStatistics` instead of `extrema`. 