### PR TITLE
Add Var.reverse_dim

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,18 @@ julia> ClimaAnalysis.global_rmse_pfull(sim_var, obs_var, sim_pressure = pressure
 3.4
 ```
 
+### Reversing a dimension
+Before, a `OutputVar` will not be created, if the dimensions are not in increasing order.
+This is because an interpolant cannot be made in this case. With this release, the condition
+is relaxed, so that a `OutputVar` can be made, but an interpolant is not made. The function
+`Var.reverse_dim` is provided to reverse the order of a dimension by name. See the example
+below.
+
+```julia
+# Reversing pressure levels so that an interpolant can be made
+var_reversed = ClimaAnalysis.reverse_dim(var, "pressure_level")
+```
+
 ## Bug fixes
 - `Atmos.to_pressure_coordinates` now works with Unitful units.
 - `Atmos.to_pressure_coordinates` now uses reasonable pressure values when `target_pressure`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -76,6 +76,7 @@ Var.apply_landmask
 Var.apply_oceanmask
 Var.make_lonlat_mask
 Base.replace(var::OutputVar, old_new::Pair...)
+Var.reverse_dim
 ```
 
 ## Leaderboard

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -123,7 +123,7 @@ dimensions in either `OutputVar`s are missing units, the dimensions between the
 `OutputVar`s do not agree, or the data in `src_var` is not defined everywhere on
 the dimensions in `dest_var`.
 
-```@julia resampled_as
+```julia
 julia> src_var.data
 3×4 Matrix{Float64}:
  1.0  4.0  7.0  10.0
@@ -160,16 +160,26 @@ respectively, in a `OutputVar`. The result of `apply_landmask(var)` is data of `
 any coordinate corresponding to land is zero. Similarly, the result of `apply_oceanmask(var)` is
 data of `var`, where any coordinate corresponding to ocean is zero.
 
-```@julia masks
+```julia masks
 var_no_land = ClimaAnalysis.apply_landmask(var)
 var_no_ocean = ClimaAnalysis.apply_oceanmask(var)
 ```
 
 ## How do I replace `NaN` and `missing` values in the data of a `OutputVar` with 0.0?
 
-You can use `replace` to replace all `NaN` and `missing` values in the  data of a
+You can use `replace` to replace all `NaN` and `missing` values in the data of a
 `OutputVar` with 0.0. See the example below of this usage.
 
 ```julia
 var_no_nan_and_missing = ClimaAnalysis.replace(var, missing => 0.0, NaN => 0.0)
+```
+
+## How do I reverse a dimension so that an interpolant can be made?
+
+You can use `reverse_dim` to reverse a dimension by name. See the example below of this
+usage.
+
+```julia
+# Reversing pressure levels so that an interpolant can be made
+var_reversed = reverse_dim(var, "pressure_level")
 ```

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -112,6 +112,15 @@ function _make_interpolant(dims, data)
         return nothing
     end
 
+    # Dimensions are all 1D, check that the knots are in increasing order (as required by
+    # Interpolations.jl)
+    for (dim_name, dim_array) in dims
+        if !issorted(dim_array)
+            @warn "Dimension $dim_name is not in increasing order. An interpolant will not be created. See Var.reverse_dim if the dimension is in decreasing order"
+            return nothing
+    end
+    end
+
     # Dimensions are all 1D, check that they are compatible with data
     size_data = size(data)
     for (dim_index, (dim_name, dim_array)) in enumerate(dims)

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -1867,3 +1867,30 @@ end
     var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
     @test_throws ErrorException ClimaAnalysis.make_lonlat_mask(var)
 end
+
+@testset "Reverse dimensions" begin
+    lat = reverse(collect(range(-89.5, 89.5, 180)))
+    lon = collect(range(-179.5, 179.5, 360))
+    data = reshape(collect(1:(360 * 180)), (180, 360))
+    dims = OrderedDict(["lat" => lat, "lon" => lon])
+    attribs = Dict("long_name" => "hi")
+    dim_attribs = OrderedDict(["lon" => Dict("units" => "deg")])
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+
+    @test isnothing(var.interpolant)
+
+    reverse_var = ClimaAnalysis.reverse_dim(var, "lat")
+    @test reverse(lat) == reverse_var.dims["lat"]
+    @test reverse(data, dims = 1) == reverse_var.data
+
+    # Error handling
+    @test_throws ErrorException ClimaAnalysis.reverse_dim(var, "pressure_level")
+
+    arb_dim = reshape(collect(range(-89.5, 89.5, 16)), (4, 4))
+    data = collect(1:16)
+    dims = OrderedDict(["arb_dim" => arb_dim])
+    attribs = Dict("long_name" => "hi")
+    dim_attribs = OrderedDict(["arb_dim" => Dict("units" => "idk")])
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+    @test_throws ErrorException ClimaAnalysis.reverse_dim(var, "arb_dim")
+end


### PR DESCRIPTION
closes #154 - With this PR, a `OutputVar` can still be made even if the dimension is in decreasing order. We do this by not creating an interpolant. Additionally, the function `Var.reverse_dim` is added so that a dimension can be reversed to make an interpolant. 