### PR TITLE
Var.dim_units return a string

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@ var_reversed = ClimaAnalysis.reverse_dim(var, "pressure_level")
   is not specified. In particular, the vertical dimension is mapped to pressure levels by z
   -> P0 * exp(-z / H_EARTH), where P0 = 10000 and H_EARTH = 7000.0, following a simple
   hydrostatic model for the atmosphere.
+- `Var.dim_units` returns a string even if the type of the units is Unitful.
 
 v0.5.11
 -------

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -771,7 +771,7 @@ function dim_units(var::OutputVar, dim_name)
     !haskey(var.dims, dim_name) &&
         error("Var does not have dimension $dim_name, found $(keys(var.dims))")
     # Double get because var.dim_attributes is a dictionry whose values are dictionaries
-    get(get(var.dim_attributes, dim_name, Dict()), "units", "")
+    string(get(get(var.dim_attributes, dim_name, Dict()), "units", ""))
 end
 
 """

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -525,12 +525,13 @@ end
     dims = OrderedDict(["time" => time, "x" => x, "y" => y])
     dim_attributes = OrderedDict([
         "time" => Dict("units" => "seconds"),
-        "x" => Dict("units" => "km"),
+        "x" => Dict("units" => u"km"),
     ])
     attribs = Dict("long_name" => "hi")
     var = ClimaAnalysis.OutputVar(attribs, dims, dim_attributes, data)
 
     @test ClimaAnalysis.dim_units(var, "y") == ""
+    @test ClimaAnalysis.dim_units(var, "time") == "seconds"
     @test ClimaAnalysis.dim_units(var, "x") == "km"
     @test ClimaAnalysis.range_dim(var, "x") == (0.0, 180.0)
     @test_throws ErrorException(


### PR DESCRIPTION
closes #161 - This PR makes it so `Var.dim_units` always return a string.