### PR TITLE
Add periodic boundary condition when lat is 360°

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,8 @@ var_reversed = ClimaAnalysis.reverse_dim(var, "pressure_level")
   -> P0 * exp(-z / H_EARTH), where P0 = 10000 and H_EARTH = 7000.0, following a simple
   hydrostatic model for the atmosphere.
 - `Var.dim_units` returns a string even if the type of the units is Unitful.
+- Add periodic boundary condition when extrapolating on longitude dimension when it is
+  exactly 360 degrees
 
 v0.5.11
 -------

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -167,6 +167,10 @@ function _find_extp_bound_cond(dim_name, dim_array)
         isapprox(dim_size + dsize, 360.0)
     ) && return Intp.Periodic()
     (
+        conventional_dim_name(dim_name) == "longitude" &&
+        (dim_array[end] - dim_array[begin]) ≈ 360.0
+    ) && return Intp.Periodic()
+    (
         conventional_dim_name(dim_name) == "latitude" &&
         _isequispaced(dim_array) &&
         isapprox(dim_size + dsize, 180.0)

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -121,6 +121,13 @@ end
     var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
     @test var.interpolant.et == (Intp.Throw(), Intp.Throw(), Intp.Throw())
 
+    # Lon is exactly 360 degrees
+    lon = 0.0:1.0:360.0 |> collect
+    data = ones(length(lon))
+    dims = OrderedDict(["lon" => lon])
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+    @test var.interpolant.et == (Intp.Periodic(),)
+
     # Dates for the time dimension
     lon = 0.5:1.0:359.5 |> collect
     lat = -89.5:1.0:89.5 |> collect


### PR DESCRIPTION
closes #163  - When the difference between the longitude dimension is exactly 360.0 degrees, then a periodic boundary condition is added.