### PR TITLE
Lazily convert to Unitful

### DIFF
--- a/ext/ClimaAnalysisUnitfulExt.jl
+++ b/ext/ClimaAnalysisUnitfulExt.jl
@@ -49,8 +49,9 @@ function Var.convert_units(
     new_units::AbstractString;
     conversion_function = nothing,
 )
-    has_unitful_units =
-        Var.has_units(var) && (var.attributes["units"] isa Unitful.Units)
+    maybe_unitful_units =
+        Var.has_units(var) && (Var.units(var) |> Var._maybe_convert_to_unitful)
+    has_unitful_units = maybe_unitful_units isa Unitful.Units
     new_units_maybe_unitful = Var._maybe_convert_to_unitful(new_units)
     new_units_are_unitful = new_units_maybe_unitful isa Unitful.Units
 
@@ -60,7 +61,7 @@ function Var.convert_units(
         convert_function =
             data -> _converted_data_unitful(
                 data,
-                var.attributes["units"],
+                maybe_unitful_units,
                 new_units_maybe_unitful,
             )
     else
@@ -72,7 +73,7 @@ function Var.convert_units(
 
     new_data = convert_function(var.data)
     new_attribs = copy(var.attributes)
-    # The constructor will take care of converting new_units to Unitful
+    # Units will be a string and not Unitful
     new_attribs["units"] = new_units
 
     return Var.OutputVar(new_attribs, var.dims, var.dim_attributes, new_data)

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -186,18 +186,6 @@ function OutputVar(attribs, dims, dim_attribs, data)
         end
     end
 
-    function _maybe_process_key_value(k, v)
-        k != "units" && return k => v
-        return k => _maybe_convert_to_unitful(v)
-    end
-
-    # Recreating an object to ensure that the type is correct
-    if !isempty(attribs)
-        attribs = Dict(_maybe_process_key_value(k, v) for (k, v) in attribs)
-    end
-
-    # TODO: Support units for dimensions too
-
     return OutputVar(
         attribs,
         OrderedDict(dims),

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -28,8 +28,8 @@ import Dates
         data,
     )
 
-    @test ClimaAnalysis.units(var_with_unitful) == "m s^-1"
-    @test var_with_unitful.attributes["units"] == u"m" / u"s"
+    @test ClimaAnalysis.units(var_with_unitful) == "m/s"
+    @test var_with_unitful.attributes["units"] == "m/s"
 
     # Unparsable unit
     attribs = Dict("long_name" => "hi", "units" => "bob")
@@ -1160,7 +1160,7 @@ end
     @test squared_error_var.data == (data_ones - data_threes) .^ 2
     @test ClimaAnalysis.short_name(squared_error_var) == "(sim-obs)^2_short"
     @test ClimaAnalysis.long_name(squared_error_var) == "(SIM - OBS)^2 short"
-    @test ClimaAnalysis.units(squared_error_var) == "kg^2"
+    @test ClimaAnalysis.units(squared_error_var) == "(kg)^2"
 
     # Flip order in squared_error and check computations
     squared_error_var = ClimaAnalysis.squared_error(var_threes, var_ones)
@@ -1201,7 +1201,7 @@ end
     var_unitful = ClimaAnalysis.squared_error(var_unitful, var_unitful)
     var_not_unitful =
         ClimaAnalysis.squared_error(var_not_unitful, var_not_unitful)
-    @test ClimaAnalysis.units(var_unitful) == "(kg^2 m^-1)^2"
+    @test ClimaAnalysis.units(var_unitful) == "(kg^2/m)^2"
     @test ClimaAnalysis.units(var_not_unitful) == "(wacky/weird^2)^2"
 end
 


### PR DESCRIPTION
closes #160 - This commit makes it, so that units are only converted to an Unitful object when converting to different units.

This also helps to make it easier to use the Unitful backend for dimensions - #71 
