### PR TITLE
Add error hints for package extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,11 @@ However, functions like `resampled_as` and interpolating using a `OutputVar` wil
 as an interpolant must be generated. This means repeated calls to these functions will be
 slower compared to the previous versions of ClimaAnalysis.
 
+## Better error messages
+There is now error hints when using a function that requires another package such as Makie
+or GeoMakie to be loaded as well. The error hint tells the user which package need to be
+loaded in, so that the function can be used.
+
 v0.5.12
 -------
 

--- a/src/Visualize.jl
+++ b/src/Visualize.jl
@@ -34,4 +34,54 @@ function plot_boxplot! end
 
 function plot_leaderboard! end
 
+extension_fns = [
+    :Makie => [
+        :heatmap2D!,
+        :sliced_heatmap!,
+        :heatmap!,
+        :line_plot1D!,
+        :sliced_line_plot!,
+        :line_plot!,
+        :sliced_plot!,
+        :plot!,
+        :plot_boxplot!,
+        :plot_leaderboard!,
+        :_constrained_cmap,
+    ],
+    :GeoMakie => [
+        :oceanmask,
+        :landmask,
+        :heatmap2D_on_globe!,
+        :contour2D_on_globe!,
+        :plot_bias_on_globe!,
+    ],
+]
+
+"""
+    is_pkg_loaded(pkg::Symbol)
+
+Check if `pkg` is loaded or not.
+"""
+function is_pkg_loaded(pkg::Symbol)
+    return any(k -> Symbol(k.name) == pkg, keys(Base.loaded_modules))
+end
+
+function __init__()
+    # Register error hint if a package is not loaded
+    if isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(
+            MethodError,
+        ) do io, exc, _argtypes, _kwargs
+            for (pkg, fns) in extension_fns
+                if Symbol(exc.f) in fns && !is_pkg_loaded(pkg)
+                    print(
+                        io,
+                        "\nImport $pkg to enable `$(exc.f)`. You might also need to import Makie and its backends (CairoMakie, GLMake, etc.) as well.";
+                    )
+                end
+            end
+        end
+    end
+end
+
 end


### PR DESCRIPTION
closes #15 - This PR adds error hints for functions in the package extensions.

For example, if you run this
```julia
import ClimaAnalysis.Visualize as viz
import ClimaAnalysis
import Makie
using OrderedCollections
long = 0.0:180.0 |> collect
lat = 0.0:90.0 |> collect
data2D = reshape(1.0:(91 * 181), (181, 91))
dims2D = OrderedDict(["lon" => long, "lat" => lat])
attribs = Dict([
    "short_name" => "name",
    "units" => "units"
])
dim_attributes2D = OrderedDict([
    "lon" => Dict(["units" => "degrees"]),
    "lat" => Dict(["units" => "degrees"]),
])
var2D = ClimaAnalysis.OutputVar(attribs, dims2D, dim_attributes2D, data2D)
fig = Makie.Figure()

viz.heatmap2D_on_globe!(fig, var2D)
```
Then, you get the error
```julia
ERROR: MethodError: no method matching heatmap2D_on_globe!(::Makie.Figure, ::ClimaAnalysis.Var.OutputVar{Vector{…}, Base.ReshapedArray{…}, String, Dict{…}})
The function `heatmap2D_on_globe!` exists, but no method is defined for this combination of argument types.
Import GeoMakie to enable `heatmap2D_on_globe!`. You might also need to import Makie and its backends (CairoMakie, GLMake, etc.) as well.
```