### PR TITLE
add center_longitude! at 0 test

### DIFF
--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -84,6 +84,15 @@ import Dates
         Dict("time" => time),
         [1],
     )
+
+    # Centering at 0 doesn't work - I would expect this to produce longitude in [-180, 180]
+    long = 0.0:360.0 |> collect
+    data = copy(long)
+    longvar = ClimaAnalysis.OutputVar(Dict("long" => long), data)
+
+    @test extrema(longvar.dims["long"]) == (0.0, 360.0)
+    ClimaAnalysis.center_longitude!(longvar, 0.0)
+    @test_broken extrema(longvar.dims["long"]) == (-180.0, 180.0)
 end
 
 @testset "Remake" begin
@@ -602,7 +611,7 @@ end
     @test xy_avg.attributes["long_name"] ==
           "hi averaged horizontally over x (0.0 to 180.0km) and y (0.0 to 90.0km)"
 
-    # Setup to test average_lat and average_lon 
+    # Setup to test average_lat and average_lon
     long = 0.0:180.0 |> collect
     lat = 0.0:90.0 |> collect
     time = 0.0:10.0 |> collect


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
I encountered a problem when plotting with Makie, where plotting a variable with longitude in [0, 360] produces an improper plot (see https://github.com/MakieOrg/GeoMakie.jl/issues/290). I wanted to use `center_longitude!` to recenter the longitude at 0 and produce longitude in `[-180, 180]`, but calling `center_longitude!(var, 0)` maintains `extrema(var.dims["long"]) == (0.0, 360.0)`, due to the use of `circshift`.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
