### PR TITLE
Add partial resampling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,14 @@ corresponding to a distinct date. Even though 2010-01-01 and 2010-12-01 are in t
 season, there are two `OutputVar`s, because the dates do not belong in the same season and
 year.
 
+## Partial resampling
+Sometimes, it is necessary to resample over a subset of all the dimensions of a variable
+(e.g., resample the spatial dimensions while preserving the temporal ones). `resampled_as`
+now includes a new keyword argument to allow this. When called with `dim_names`,
+`resampled_as` will resample only the specified dimensions. For example, if one wants to
+resample only over longitude and latitude, then one can use
+`resampled_as(src_var, dest_var, dim_names = ["longitude, "latitude"])`.
+
 v0.5.13
 -------
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -56,6 +56,7 @@ Var.has_latitude
 Var.has_altitude
 Var.has_pressure
 Var.conventional_dim_name
+Var.find_corresponding_dim_name
 Var.dim_units
 Var.range_dim
 Var.reordered_as

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -118,39 +118,67 @@ You can use the `resampled_as(src_var, dest_var)` function where `src_var` is a
 OutputVar with the data you want to resample using the dimensions in another
 OutputVar `dest_var`. If resampling is possible, then a new `OutputVar` is
 returned where the data in `src_var` is resampled using a linear interpolation
-to fit the dimensions in `dest_var`. Resampling is not possible when the
+to fit the dimensions in `dest_var`. Resampling only over selected dimensions is
+possible with the keyword `dim_names`. Resampling is not possible when the
 dimensions in either `OutputVar`s are missing units, the dimensions between the
 `OutputVar`s do not agree, or the data in `src_var` is not defined everywhere on
 the dimensions in `dest_var`.
 
-```julia
-julia> src_var.data
-3×4 Matrix{Float64}:
- 1.0  4.0  7.0  10.0
- 2.0  5.0  8.0  11.0
- 3.0  6.0  9.0  12.0
+```@setup resampled_as
+import ClimaAnalysis
+import OrderedCollections: OrderedDict
 
-julia> src_var.dims
-OrderedDict{String, Vector{Float64}} with 2 entries:
-  "lon"      => [0.0, 1.0, 2.0]
-  "latitude" => [0.0, 1.0, 2.0, 3.0]
+src_lon = [0.0, 1.0, 2.0]
+src_lat = [0.0, 1.0, 2.0, 3.0]
+src_var_data = reshape(1.0:12.0, (3,4)) |> Array
+src_dims = OrderedDict("lon" => src_lon, "latitude" => src_lat)
+src_dim_attribs = OrderedDict("lon" => Dict("units" => "degrees"), "latitude" => Dict("units" => "degrees"))
+src_attribs = Dict("long_name" => "hi")
+src_var = ClimaAnalysis.OutputVar(src_attribs, src_dims, src_dim_attribs, src_var_data)
 
-julia> dest_var.dims # dims that src_var.data should be resampled on
-OrderedDict{String, Vector{Float64}} with 2 entries:
-  "long" => [0.0, 1.0]
-  "lat"  => [0.0, 1.0, 2.0]
+dest_long = [0.0, 1.0]
+dest_lat = [0.0, 1.0, 2.0]
+dest_var_data = [[1.0, 2.0]  [4.0, 5.0]  [7.0, 8.0]]
+dest_dims = OrderedDict("long" => dest_long, "lat" => dest_lat)
+dest_dim_attribs = OrderedDict("long" => Dict("units" => "degrees"), "lat" => Dict("units" => "degrees"))
+dest_attribs = Dict("long_name" => "hi")
+dest_var = ClimaAnalysis.OutputVar(dest_attribs, dest_dims, dest_dim_attribs, dest_var_data)
+```
 
-julia> resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var);
+```@repl resampled_as
+src_var.data
+src_var.dims
+dest_var.dims
+resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var);
+resampled_var.data
+resampled_var.dims # updated dims that are the same as the dims in dest_var
+```
 
-julia> resampled_var.data
-2×3 Matrix{Float64}:
- 1.0  4.0  7.0
- 2.0  5.0  8.0
+## How do I resample the data in a `OutputVar` using only a subset of dimensions from another `OutputVar`?
 
-julia> resampled_var.dims # updated dims that are the same as the dims in dest_var
-OrderedDict{String, Vector{Float64}} with 2 entries:
-  "lon"      => [0.0, 1.0]
-  "latitude" => [0.0, 1.0, 2.0]
+!!! compat "`dim_names` keyword argument"
+    The keyword argument `dim_names` for `resampled_as` is introduced in
+    ClimaAnalysis v0.5.14.
+
+You can use the `dim_names` keyword argument in `resampled_as(src_var,
+dest_var)` function where `src_var` is a `OutputVar` with the data you want to
+resample using the dimensions in another `OutputVar` `dest_var`.
+
+The argument `dim_names` can either be a string or an iterable such as an array
+of strings. The correct dimension is identified by using
+`conventional_dim_name`. For example, if `src_var` has a longitude dimension
+named `lon`, `dest_var` has a longitude dimension named `long`, and `dim_names`
+is `longitude`, then resampling is done on the longitude dimension because
+`conventional_dim_name` maps `lon`, `long`, and `longitude` to `longitude`.
+
+```@repl resampled_as
+src_var.data
+src_var.dims
+dest_var.dims
+partial_resampled_var = # dim_names is either a string or an iterable
+    ClimaAnalysis.resampled_as(src_var, dest_var, dim_names = "longitude");
+partial_resampled_var.data
+partial_resampled_var.dims
 ```
 
 ## How do I apply a land or sea mask to a `OutputVar`?

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -24,7 +24,8 @@ export times,
     has_latitude,
     has_altitude,
     has_pressure,
-    conventional_dim_name
+    conventional_dim_name,
+    find_corresponding_dim_name
 
 """
     _dim_name(dim_names, allowed_names)
@@ -208,4 +209,36 @@ function conventional_dim_name(dim_name::AbstractString)
     dim_name in ALTITUDE_NAMES && return "altitude"
     dim_name in PRESSURE_NAMES && return "pressure"
     return dim_name
+end
+
+"""
+    find_corresponding_dim_name(dim_name::AbstractString, dim_names::Iterable)
+
+Find the corresponding dimension name in `dim_names` that matches `dim_name`.
+
+Two names for a dimension match if both correspond to the same conventional name
+as determined by `Var.conventional_dim_name`.
+
+Example
+==========
+
+```jldoctest
+julia> ClimaAnalysis.Var.find_corresponding_dim_name("longitude", ["lat", "lon"])
+"lon"
+
+julia> ClimaAnalysis.Var.find_corresponding_dim_name("time", ["lat", "lon", "t"])
+"t"
+
+julia> ClimaAnalysis.Var.find_corresponding_dim_name("height", ["lat", "lon", "height"])
+"height"
+```
+"""
+function find_corresponding_dim_name(dim_name::AbstractString, dim_names)
+    dim_names = collect(dim_names)
+    standard_dim_name = conventional_dim_name(dim_name)
+    corresponding_dim_name =
+        _dim_name([standard_dim_name], conventional_dim_name.(dim_names))
+    isnothing(corresponding_dim_name) &&
+        error("Cannot find corresponding dimension for $dim_name in $dim_names")
+    return dim_names[corresponding_dim_name]
 end

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -997,7 +997,7 @@ end
     @test_throws ErrorException ClimaAnalysis.reordered_as(src_var, dest_var)
 end
 
-@testset "Resampling" begin
+@testset "Resampling over all dimensions" begin
     src_long = 0.0:180.0 |> collect
     src_lat = 0.0:90.0 |> collect
     src_data = reshape(1.0:(181 * 91), (181, 91))
@@ -1040,6 +1040,172 @@ end
         ClimaAnalysis.remake(dest_var, data = dest_data, dims = dest_dims)
 
     @test_throws BoundsError ClimaAnalysis.resampled_as(src_var, dest_var)
+end
+
+@testset "Resampling with dim_names keyword" begin
+    src_long = 0.0:180.0 |> collect
+    src_lat = 0.0:90.0 |> collect
+    src_data = reshape(1.0:(181 * 91), (181, 91))
+    src_dims = OrderedDict(["long" => src_long, "lat" => src_lat])
+    src_attribs = Dict("long_name" => "hi")
+    src_dim_attribs = OrderedDict([
+        "long" => Dict("units" => "test_units1"),
+        "lat" => Dict("units" => "test_units2"),
+    ])
+    src_var = ClimaAnalysis.OutputVar(
+        src_attribs,
+        src_dims,
+        src_dim_attribs,
+        src_data,
+    )
+
+    dest_long = 0.0:90.0 |> collect
+    dest_lat = 0.0:45.0 |> collect
+    dest_data = reshape(1.0:(91 * 46), (91, 46))
+    dest_dims = OrderedDict(["long" => dest_long, "lat" => dest_lat])
+    dest_var = ClimaAnalysis.remake(src_var, data = dest_data, dims = dest_dims)
+
+    # Resampling over all dimensions with dim_names (should be the same as resampled_as)
+    resampled_src_var1 = ClimaAnalysis.resampled_as(
+        src_var,
+        dest_var,
+        dim_names = ["latitude", "longitude"],
+    )
+    resampled_src_var2 = ClimaAnalysis.resampled_as(src_var, dest_var)
+    @test resampled_src_var1.data == resampled_src_var2.data
+    @test resampled_src_var1.dims == resampled_src_var2.dims
+
+    # Resampling an OutputVar with small number of dimensions (src_var) on an OutputVar with a large number of dimensions (dest_var)
+    dest_time = 0.0:3.0 |> collect
+    dest_long = 0.0:42.0 |> collect
+    dest_pfull = 0.0:10.0 |> collect
+    dest_data = reshape(
+        1.0:(length(dest_time) * length(dest_long) * length(dest_pfull)),
+        (length(dest_time), length(dest_long), length(dest_pfull)),
+    )
+    dest_dims = OrderedDict([
+        "time" => dest_time,
+        "lon" => dest_long,
+        "pfull" => dest_pfull,
+    ])
+    dest_attribs = Dict("long_name" => "hi")
+    dest_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "test_units1"),
+        "lat" => Dict("units" => "test_units2"),
+    ])
+    dest_var = ClimaAnalysis.OutputVar(
+        dest_attribs,
+        dest_dims,
+        dest_dim_attribs,
+        dest_data,
+    )
+    resampled_src_var =
+        ClimaAnalysis.resampled_as(src_var, dest_var, dim_names = "longitude")
+    @test resampled_src_var.data == src_var.data[1:43, :]
+    @test resampled_src_var.dims["long"] == dest_var.dims["lon"]
+
+    # Resample OutputVar with 2 dimensions (src_var) on an OutputVar
+    # with 3 dimensions (dest_var) with two dimensions being
+    # resampled and in different order in both OutputVars
+    dest_lat = 0.0:3.0 |> collect
+    dest_long = 0.0:42.0 |> collect
+    dest_pull = 0.0:10.0 |> collect
+    dest_data = reshape(
+        1.0:(length(dest_lat) * length(dest_long) * length(dest_pfull)),
+        (length(dest_lat), length(dest_long), length(dest_pfull)),
+    )
+    dest_dims = OrderedDict([
+        "latitude" => dest_lat,
+        "longitude" => dest_long,
+        "pfull" => dest_pfull,
+    ])
+    dest_attribs = Dict("long_name" => "hi")
+    dest_dim_attribs = OrderedDict([
+        "latitude" => Dict("units" => "test_units2"),
+        "longitude" => Dict("units" => "test_units1"),
+    ])
+    dest_var = ClimaAnalysis.OutputVar(
+        dest_attribs,
+        dest_dims,
+        dest_dim_attribs,
+        dest_data,
+    )
+    resampled_src_var = ClimaAnalysis.resampled_as(
+        src_var,
+        dest_var,
+        dim_names = ["lon", "latitude"],
+    )
+    @test resampled_src_var.data == src_var.data[1:43, 1:4]
+    @test resampled_src_var.dims["lat"] == dest_var.dims["latitude"]
+    @test resampled_src_var.dims["long"] == dest_var.dims["longitude"]
+
+    # Resample OutputVar with 3 dimensions (src_var) on an OutputVar
+    # with 2 dimensions (dest_var) with two dimensions being
+    # resampled and in different order in both OutputVars
+    src_long = 0.0:60.0 |> collect
+    src_lat = 0.0:30.0 |> collect
+    src_time = 0.0:5.0 |> collect
+    src_data = reshape(
+        1.0:(length(src_long) * length(src_lat) * length(src_time)),
+        (length(src_long), length(src_lat), length(src_time)),
+    )
+    src_dims =
+        OrderedDict(["long" => src_long, "lat" => src_lat, "time" => src_time])
+    src_attribs = Dict("long_name" => "hi")
+    src_dim_attribs = OrderedDict([
+        "long" => Dict("units" => "test_units1"),
+        "lat" => Dict("units" => "test_units2"),
+        "time" => Dict("units" => "seconds"),
+    ])
+    src_var = ClimaAnalysis.OutputVar(
+        src_attribs,
+        src_dims,
+        src_dim_attribs,
+        src_data,
+    )
+
+    dest_t = 0.0:3.0 |> collect
+    dest_longitude = 0.0:45.0 |> collect
+    dest_data = reshape(
+        1.0:(length(dest_t) * length(dest_longitude)),
+        (length(dest_t), length(dest_longitude)),
+    )
+    dest_dims = OrderedDict(["t" => dest_t, "longitude" => dest_longitude])
+    dest_attribs = Dict("long_name" => "hi")
+    dest_dim_attribs = OrderedDict([
+        "t" => Dict("units" => "seconds"),
+        "longitude" => Dict("units" => "test_units1"),
+    ])
+    dest_var = ClimaAnalysis.OutputVar(
+        dest_attribs,
+        dest_dims,
+        dest_dim_attribs,
+        dest_data,
+    )
+    resampled_src_var =
+        ClimaAnalysis.resampled_as(src_var, dest_var, dim_names = ["long", "t"])
+    @test resampled_src_var.data == src_var.data[1:46, :, 1:4]
+    @test resampled_src_var.dims["time"] == dest_var.dims["t"]
+    @test resampled_src_var.dims["long"] == dest_var.dims["longitude"]
+
+    # Error handling
+    # Out of bound errors
+    dest_long = 0.0:200.0 |> collect
+    dest_data = ones(length(dest_long))
+    dest_dims = OrderedDict(["long" => dest_long])
+    dest_attribs = Dict("long_name" => "hi")
+    dest_dim_attribs = OrderedDict(["long" => Dict("units" => "test_units1")])
+    dest_var = ClimaAnalysis.OutputVar(
+        dest_attribs,
+        dest_dims,
+        dest_dim_attribs,
+        dest_data,
+    )
+    @test_throws BoundsError ClimaAnalysis.resampled_as(
+        src_var,
+        dest_var,
+        dim_names = "longitude",
+    )
 end
 
 @testset "Units" begin

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -524,6 +524,22 @@ end
     @test ClimaAnalysis.conventional_dim_name("z") == "altitude"
     @test ClimaAnalysis.conventional_dim_name("hi") == "hi"
     @test ClimaAnalysis.conventional_dim_name("pfull") == "pressure"
+    @test ClimaAnalysis.find_corresponding_dim_name(
+        "lat",
+        ["latitude", "longitude"],
+    ) == "latitude"
+    @test ClimaAnalysis.find_corresponding_dim_name(
+        "lat",
+        ["longitude", "latitude"],
+    ) == "latitude"
+    @test ClimaAnalysis.find_corresponding_dim_name(
+        "hi",
+        ["longitude", "hi"],
+    ) == "hi"
+    @test_throws ErrorException ClimaAnalysis.find_corresponding_dim_name(
+        "lat",
+        ["longitude", "pfull"],
+    )
 
     # Pressure dim
     pressure = 0:100.0 |> collect

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -716,13 +716,13 @@ end
 
     # Test if type of dimensions agree
     x_data = reshape(1.0:(91 * 181), (91, 181))
-    x_dims = OrderedDict(["lat" => x_lat, "long" => x_long])
+    x_dims = OrderedDict(["t" => x_lat, "pfull" => x_long])
     x_dim_attribs = OrderedDict([
-        "lat" => Dict("units" => "test_units1"),
-        "long" => Dict("units" => "test_units2"),
+        "t" => Dict("units" => "test_units1"),
+        "pfull" => Dict("units" => "test_units2"),
     ])
     x_var = ClimaAnalysis.OutputVar(x_attribs, x_dims, x_dim_attribs, x_data)
-    @test_throws "Dimensions do not agree between x ([\"latitude\", \"longitude\"]) and y ([\"longitude\", \"latitude\"])" ClimaAnalysis.Var._check_dims_consistent(
+    @test_throws "Dimensions do not agree between x (Set([\"time\", \"pressure\"])) and y (Set([\"latitude\", \"longitude\"]))" ClimaAnalysis.Var._check_dims_consistent(
         x_var,
         y_var,
     )
@@ -738,6 +738,177 @@ end
         y_var,
     )
 
+    # Check with keyword argument
+    x_long = 0.0:180.0 |> collect
+    x_lat = 0.0:90.0 |> collect
+    x_data = reshape(1.0:(181 * 91), (91, 181))
+    x_dims = OrderedDict(["lat" => x_lat, "long" => x_long])
+    x_attribs = Dict("long_name" => "hi")
+    x_dim_attribs = OrderedDict([
+        "lat" => Dict("units" => "test_units2"),
+        "long" => Dict("units" => "test_units1"),
+    ])
+    x_var = ClimaAnalysis.OutputVar(x_attribs, x_dims, x_dim_attribs, x_data)
+
+    y_long = 0.0:180.0 |> collect
+    y_pfull = 0.0:2.0 |> collect
+    y_time = 0.0:3.0 |> collect
+    y_data = ones(length(y_long), length(y_pfull), length(y_time))
+    y_dims = OrderedDict(["lon" => y_long, "pfull" => y_pfull, "t" => y_time])
+    y_attribs = Dict("long_name" => "hello")
+    y_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "test_units1"),
+        "pfull" => Dict("units" => "something"),
+        "time" => Dict("units" => "idk"),
+    ])
+    y_var = ClimaAnalysis.OutputVar(y_attribs, y_dims, y_dim_attribs, y_data)
+    @test_nowarn ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["longitude"],
+    )
+    @test_nowarn ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = "longitude",
+    )
+
+    # Test if dimension is not present in x or y
+    @test_throws "Cannot find space in the dimension names of x ([\"latitude\", \"longitude\"])" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["space"],
+    )
+    # Test if dimension is present in only one of them
+    @test_throws "Cannot find latitude in the dimension names of y ([\"longitude\", \"pressure\", \"time\"])" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = "lat",
+    )
+
+    # Test if units are consistent between dimensions
+    x_dim_attribs = OrderedDict([
+        "lat" => Dict("units" => "test_units2"),
+        "long" => Dict("units" => "this should not"),
+    ])
+    y_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "be the same"),
+        "pfull" => Dict("units" => "something"),
+        "time" => Dict("units" => "idk"),
+    ])
+    x_var = ClimaAnalysis.remake(x_var, dim_attributes = x_dim_attribs)
+    y_var = ClimaAnalysis.remake(y_var, dim_attributes = y_dim_attribs)
+    @test_throws "Units for dimensions [\"long\"] in x is not consistent with units for dimensions [\"lon\"] in y" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = "longitude",
+    )
+
+    # Test if units are missing from any of the dimensions
+    x_dim_attribs = OrderedDict([
+        "lat" => Dict("units" => "test_units2"),
+        "long" => Dict("units" => ""),
+    ])
+    y_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => ""),
+        "pfull" => Dict("units" => "something"),
+        "time" => Dict("units" => "idk"),
+    ])
+    x_var = ClimaAnalysis.remake(x_var, dim_attributes = x_dim_attribs)
+    y_var = ClimaAnalysis.remake(y_var, dim_attributes = y_dim_attribs)
+    @test_throws "Units for dimensions [\"long\"] are missing in x and units for dimensions [\"lon\"] are missing in y" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = "longitude",
+    )
+
+    # Test with more than one dimension supplied for keyword argument
+    x_pfull = 0.0:10.0 |> collect
+    x_lat = 0.0:90.0 |> collect
+    x_long = 0.0:180.0 |> collect
+    x_data = reshape(1.0:(11 * 181 * 91), (11, 91, 181))
+    x_dims = OrderedDict([
+        "pressure_level" => x_pfull,
+        "lat" => x_lat,
+        "long" => x_long,
+    ])
+    x_attribs = Dict("long_name" => "hi")
+    x_dim_attribs = OrderedDict([
+        "pressure_level" => Dict("units" => "something"),
+        "lat" => Dict("units" => "test_units2"),
+        "long" => Dict("units" => "test_units1"),
+    ])
+    x_var = ClimaAnalysis.OutputVar(x_attribs, x_dims, x_dim_attribs, x_data)
+
+    y_long = 0.0:180.0 |> collect
+    y_pfull = 0.0:2.0 |> collect
+    y_time = 0.0:3.0 |> collect
+    y_data = ones(length(y_long), length(y_pfull), length(y_time))
+    y_dims = OrderedDict(["lon" => y_long, "pfull" => y_pfull, "t" => y_time])
+    y_attribs = Dict("long_name" => "hello")
+    y_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "test_units1"),
+        "pfull" => Dict("units" => "something"),
+        "time" => Dict("units" => "idk"),
+    ])
+    y_var = ClimaAnalysis.OutputVar(y_attribs, y_dims, y_dim_attribs, y_data)
+    @test_nowarn ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["longitude", "pfull"],
+    )
+
+    # Test if dimension is not present in x or y
+    @test_throws "Cannot find no in the dimension names of x ([\"pressure\", \"latitude\", \"longitude\"])" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["no", "dim"],
+    )
+
+    # Test if dimension is present in only one of them
+    @test_throws "Cannot find latitude in the dimension names of y ([\"longitude\", \"pressure\", \"time\"])" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["latitude", "lon"],
+    )
+
+    # Test if units are consistent between dimensions
+    x_dim_attribs = OrderedDict([
+        "pressure_level" => Dict("units" => "not something"),
+        "lat" => Dict("units" => "test_units2"),
+        "long" => Dict("units" => "test_units1"),
+    ])
+    y_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "test_units1"),
+        "pfull" => Dict("units" => "something"),
+        "time" => Dict("units" => "idk"),
+    ])
+    x_var = ClimaAnalysis.remake(x_var, dim_attributes = x_dim_attribs)
+    y_var = ClimaAnalysis.remake(y_var, dim_attributes = y_dim_attribs)
+    @test_throws "Units for dimensions [\"pressure_level\"] in x is not consistent with units for dimensions [\"pfull\"] in y" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["longitude", "pfull"],
+    )
+
+    # Test if units are missing from any of the dimensions
+    x_dim_attribs = OrderedDict([
+        "pressure_level" => Dict("units" => "something"),
+        "lat" => Dict("units" => "test_units2"),
+        "long" => Dict("units" => ""),
+    ])
+    y_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "test_units1"),
+        "pfull" => Dict("units" => ""),
+        "time" => Dict("units" => "idk"),
+    ])
+    x_var = ClimaAnalysis.remake(x_var, dim_attributes = x_dim_attribs)
+    y_var = ClimaAnalysis.remake(y_var, dim_attributes = y_dim_attribs)
+    @test_throws "Units for dimensions [\"long\"] are missing in x and units for dimensions [\"pfull\"] are missing in y" ClimaAnalysis.Var._check_dims_consistent(
+        x_var,
+        y_var,
+        dim_names = ["longitude", "pfull"],
+    )
 end
 
 @testset "Reordering" begin


### PR DESCRIPTION
This PR adds partial resampling by adding the keyword argument `dim_names` to `Var.resampled_as`.

We also add `Var.find_corresponding_dim_name` which allows one to find the name of the dimension in a `OutputVar` by using another dimension name. 

- [x] Add documentation for both of the functions in the API
- [x] Add features to NEWS.md
