### PR TITLE
Add valid_time to TIME_NAMES and fix issue with pretty printing

### DIFF
--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1858,7 +1858,8 @@ function Base.show(io::IO, var::OutputVar)
     # Print the key value pairs of attributes
     printstyled(io, "Attributes:\n", bold = true, color = :green)
     # Find spacing to pad out key of var.attributes
-    max_length_attribs = maximum(length(x) for (x, _) in var.attributes)
+    max_length_attribs =
+        maximum(length(x) for (x, _) in var.attributes; init = 0)
     for (key, val) in var.attributes
         print(io, "  " * rpad(key, max_length_attribs) * " => ")
         printstyled(io, "$(val)\n", color = :light_cyan)
@@ -1869,7 +1870,8 @@ function Base.show(io::IO, var::OutputVar)
     # Find spacing to pad out key of var.attributes
     for (dim, dim_attrib) in var.dim_attributes
         printstyled(io, "  $dim:\n", color = :light_green)
-        max_length_dim_attribs = maximum(length(x) for (x, _) in dim_attrib)
+        max_length_dim_attribs =
+            maximum(length(x) for (x, _) in dim_attrib; init = 0)
         for (key, val) in dim_attrib
             print(io, "    " * rpad(key, max_length_dim_attribs) * " => ")
             printstyled(io, "$(val)\n", color = :light_cyan)
@@ -1877,12 +1879,16 @@ function Base.show(io::IO, var::OutputVar)
     end
 
     # Print the dimensions that the data is defined over
-    printstyled(io, "Data defined over:\n", bold = true, color = :green)
-    max_length_dims = maximum(length(x) for (x, _) in var.dims)
-    for (dim, array) in var.dims
+    printstyled(io, "Data defined over:", bold = true, color = :green)
+    # Do not add a new line if there is nothing to print in var.dims
+    !isempty(var.dims) && print(io, "\n")
+    max_length_dims = maximum(length(x) for (x, _) in var.dims; init = 0)
+    for (i, (dim, array)) in enumerate(var.dims)
         printstyled(io, "  " * rpad(dim, max_length_dims), color = :light_green)
         print(io, " with ")
         printstyled(io, "$(length(array)) ", color = :light_cyan)
+
+        # Print contents depending on size of the dimension
         if length(array) >= 2
             print(io, "elements")
             sorted_at_all = issorted(array) || issorted(array, rev = true)
@@ -1897,14 +1903,18 @@ function Base.show(io::IO, var::OutputVar)
                 printstyled(io, "not sorted", color = :red)
                 print(io, ")")
             end
-        end
-        if length(array) == 1
+        elseif length(array) == 1
             print(io, "element")
             print(io, " (")
             printstyled(io, "$(array[begin])", color = :light_cyan)
             print(io, ")")
+        elseif length(array) == 0
+            print(io, "element")
         end
-        print(io, "\n")
+        # Do not add a new line on the last dimension
+        if i != length(var.dims)
+            print(io, "\n")
+        end
     end
 end
 

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -66,7 +66,7 @@ export OutputVar,
 """
     Representing an output variable
 """
-struct OutputVar{T <: AbstractArray, A <: AbstractArray, B, C}
+struct OutputVar{T <: AbstractArray, A <: AbstractArray, B, C <: AbstractDict}
 
     "Attributes associated to this variable, such as short/long name"
     attributes::Dict{String, B}
@@ -198,7 +198,7 @@ function OutputVar(attribs, dims, dim_attribs, data)
 end
 
 function OutputVar(dims, data)
-    return OutputVar(Dict{String, Any}(), dims, Dict{String, Any}(), data)
+    return OutputVar(Dict{String, Any}(), dims, Dict{String, Dict}(), data)
 end
 
 """
@@ -476,7 +476,7 @@ julia> data = copy(values);
 
 julia> attribs = Dict("long_name" => "speed", "units" => "m/s");
 
-julia> dim_attribs = Dict{String, Any}();
+julia> dim_attribs = Dict{String, Dict}();
 
 julia> var = ClimaAnalysis.OutputVar(attribs, Dict("distance" => values), dim_attribs, data);
 

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -1,7 +1,7 @@
 # Customize these variables to allow other names
 LONGITUDE_NAMES = ["long", "lon", "longitude"]
 LATITUDE_NAMES = ["lat", "latitude"]
-TIME_NAMES = ["t", "time"]
+TIME_NAMES = ["t", "time", "valid_time"]
 DATE_NAMES = ["date"]
 ALTITUDE_NAMES = ["z", "z_reference", "z_physical"]
 PRESSURE_NAMES = ["pfull", "pressure_level"]

--- a/test/test_Atmos.jl
+++ b/test/test_Atmos.jl
@@ -21,7 +21,7 @@ import OrderedCollections: OrderedDict
     pdata = copy(pressure)
 
     attribs = Dict("short_name" => "pfull")
-    dim_attribs = Dict{String, Any}()
+    dim_attribs = Dict{String, Dict}()
     pressure_var =
         ClimaAnalysis.OutputVar(attribs, Dict("z" => z_alt), dim_attribs, pdata)
 
@@ -46,7 +46,7 @@ import OrderedCollections: OrderedDict
     mydata = copy(myvardata)
 
     attribs = Dict("short_name" => "myvar")
-    dim_attribs = Dict{String, Any}()
+    dim_attribs = Dict{String, Dict}()
     myvar = ClimaAnalysis.OutputVar(
         attribs,
         Dict("z" => z_alt),
@@ -68,7 +68,7 @@ import OrderedCollections: OrderedDict
     exp_pdata = copy(exp_pressure)
 
     attribs = Dict("short_name" => "pfull")
-    dim_attribs = Dict{String, Any}()
+    dim_attribs = Dict{String, Dict}()
     exp_pressure_var = ClimaAnalysis.OutputVar(
         attribs,
         Dict("z" => z_alt),
@@ -159,7 +159,7 @@ import OrderedCollections: OrderedDict
     pdata = copy(pressure)
 
     attribs = Dict("short_name" => "pfull")
-    dim_attribs = Dict{String, Any}()
+    dim_attribs = Dict{String, Dict}()
     pressure_var =
         ClimaAnalysis.OutputVar(attribs, Dict("z" => z_alt), dim_attribs, pdata)
 

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -1964,21 +1964,21 @@ end
     dim_attribs = OrderedDict(["lat" => Dict("units" => "deg")])
     var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
     @test sprint(show, var) ==
-          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 180 elements (-89.5 to 89.5)\n  lon with 360 elements (-179.5 to 179.5)\n"
+          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 180 elements (-89.5 to 89.5)\n  lon with 360 elements (-179.5 to 179.5)"
 
     # Reverse lat
     lat = reverse(lat)
     dims = OrderedDict(["lat" => lat, "lon" => lon])
     var = ClimaAnalysis.remake(var, dims = dims)
     @test sprint(show, var) ==
-          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 180 elements (89.5 to -89.5)\n  lon with 360 elements (-179.5 to 179.5)\n"
+          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 180 elements (89.5 to -89.5)\n  lon with 360 elements (-179.5 to 179.5)"
 
     # Unsorted lat
     lat[1] = -1000.0
     dims = OrderedDict(["lat" => lat, "lon" => lon])
     var = ClimaAnalysis.remake(var, dims = dims)
     @test sprint(show, var) ==
-          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 180 elements (not sorted)\n  lon with 360 elements (-179.5 to 179.5)\n"
+          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 180 elements (not sorted)\n  lon with 360 elements (-179.5 to 179.5)"
 
     lat = [1.0]
     lon = [2.0]
@@ -1986,5 +1986,37 @@ end
     dims = OrderedDict(["lat" => lat, "lon" => lon])
     var = ClimaAnalysis.remake(var, data = data, dims = dims)
     @test sprint(show, var) ==
-          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 1 element (1.0)\n  lon with 1 element (2.0)\n"
+          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 1 element (1.0)\n  lon with 1 element (2.0)"
+
+    # Empty OutputVar
+    dims = OrderedDict{String, Vector{Float64}}()
+    data = Float64[]
+    empty_var = ClimaAnalysis.OutputVar(dims, data)
+    @test sprint(show, empty_var) ==
+          "Attributes:\nDimension attributes:\nData defined over:"
+
+    # OutputVar with string in dim_attributes as the value as opposed to another dictionary
+    lat = collect(range(-89.5, 89.5, 180))
+    data = ones(length(lat))
+    dims = OrderedDict(["lat" => lat])
+    attribs = Dict("long_name" => "hi")
+    dim_attribs = OrderedDict([
+        "lat" => Dict(
+            "units" => "deg",
+            "wacky" => Dict("something" => "another thing"),
+        ),
+    ])
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+    @test sprint(show, var) ==
+          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\n    wacky => Dict(\"something\" => \"another thing\")\nData defined over:\n  lat with 180 elements (-89.5 to 89.5)"
+
+    # OutputVar with 0 elements in one of the dimenisions
+    lat = Float64[]
+    data = ones(length(lat))
+    dims = OrderedDict(["lat" => lat])
+    attribs = Dict("long_name" => "hi")
+    dim_attribs = OrderedDict(["lat" => Dict("units" => "deg")])
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+    @test sprint(show, var) ==
+          "Attributes:\n  long_name => hi\nDimension attributes:\n  lat:\n    units => deg\nData defined over:\n  lat with 0 element"
 end

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -57,7 +57,7 @@ import Dates
     var_error = ClimaAnalysis.OutputVar(
         Dict{String, Any}(),
         dims,
-        Dict{String, Any}(),
+        Dict{String, Dict}(),
         data,
     )
     @test_throws ErrorException ClimaAnalysis.center_longitude!(
@@ -71,7 +71,7 @@ import Dates
     var_good = ClimaAnalysis.OutputVar(
         Dict{String, Any}(),
         dims,
-        Dict{String, Any}(),
+        Dict{String, Dict}(),
         data,
     )
     ClimaAnalysis.center_longitude!(var_good, 90.0)
@@ -530,7 +530,7 @@ end
     data = ones(length(pressure))
 
     attribs = Dict("short_name" => "K")
-    dim_attribs = Dict{String, Any}()
+    dim_attribs = Dict{String, Dict}()
     pressure_var = ClimaAnalysis.OutputVar(
         attribs,
         Dict("pfull" => pressure),
@@ -778,7 +778,7 @@ end
     src_dim_attribs_one = OrderedDict(["lat" => Dict("units" => "test_units2")])
     src_dim_attribs_empty = empty(src_dim_attribs_one)
     src_dim_attribs_extra = OrderedDict([
-        "extra_info" => "hi",
+        "extra_info" => Dict("hi" => "bye"),
         "lat" => Dict("units" => "test_units2"),
     ])
     src_var_one =
@@ -794,7 +794,7 @@ end
     reordered_var = ClimaAnalysis.reordered_as(src_var_extra, dest_var)
     @test reordered_var.dim_attributes == OrderedDict([
         "lat" => Dict("units" => "test_units2"),
-        "extra_info" => "hi",
+        "extra_info" => Dict("hi" => "bye"),
     ])
 
     # Error checking for dimensions not being the same in both


### PR DESCRIPTION
closes #204, closes #205 - The issue with pretty printing is when the `OutputVar` has empty dictionaries in which the padding cannot be computed. The other potential issue is when the value of `dim_attributes` is something that is not a dictionary.