### PR TITLE
Add Base.show for SimDir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,11 @@ Before, you could only compute an average over one dimension. With this release,
 `weighted_average_lonlat` to compute the global latitude-weighted average over the longitude
 and latitude dimensions. Both functions ignore `NaN` by default.
 
+## Show method defined for SimDir
+Previously, a brief description of `SimDir` can be printed to the terminal using
+`summary(simdir)`. With this release, the same information can also be viewed by using
+`show(simdir)`.
+
 v0.5.13
 -------
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -12,6 +12,7 @@ Base.get
 Sim.available_vars
 Sim.available_reductions
 Sim.available_periods
+Base.show(io::IO, simdir::SimDir)
 ```
 
 ## Var

--- a/src/Sim.jl
+++ b/src/Sim.jl
@@ -134,6 +134,15 @@ function Base.summary(io::IO, simdir::SimDir)
 end
 
 """
+    Base.show(io::IO, simdir::SimDir)
+
+Pretty print the contents of `simdir`.
+
+Print the output directory and the periods associated to the given variable and reduction.
+"""
+Base.show(io::IO, simdir::SimDir) = summary(io, simdir)
+
+"""
     get(simdir::SimDir;
         short_name,
         reduction = nothing,

--- a/test/test_Sim.jl
+++ b/test/test_Sim.jl
@@ -49,6 +49,27 @@ import ClimaAnalysis
     @test isempty(ClimaAnalysis.SimDir(mktempdir()))
 end
 
+@testset "Show and summary for Simdir" begin
+    simulation_path = joinpath(@__DIR__, "sample_data")
+
+    simdir = ClimaAnalysis.SimDir(simulation_path)
+
+    @test sprint(show, simdir) ==
+          "Output directory: " *
+          simulation_path *
+          "\nVariables:\n- va\n    average (2.0h)\n- pfull\n    inst (1.0d)\n- ua\n    average (6.0h)\n- orog\n    inst (nothing)\n- ta\n    average (3.0h)\n    max (4.0h, 3.0h)\n    min (3.0h)\n- ts\n    max (1.0h)"
+    @test sprint(summary, simdir) == sprint(show, simdir)
+
+    # Empty simdir
+    simdir = ClimaAnalysis.SimDir{Dict{Any, Any}, Dict{Any, Any}}(
+        "path",
+        Dict(),
+        Dict(),
+        Set(),
+    )
+    @test sprint(summary, simdir) == "Output directory: path\nVariables:"
+end
+
 @testset "OutputVar" begin
 
     simulation_path = joinpath(@__DIR__, "sample_data")


### PR DESCRIPTION
This commit uses the `Base.summary` method already defined for `SimDir` for `Base.show`.

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
