### PR TITLE
Retain attributes after doing binary operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,10 @@ Previously, a brief description of `SimDir` can be printed to the terminal using
 ## In-place functions
 With this release, there is an in-place version of `reverse_dim` which is `reverse_dim!`.
 
+## Retain attributes when doing binary operations between `OutputVar`s
+With this release, if two `OutputVar`s share the same start date, then the start date will
+remain in the resulting `OutputVar`s after performing binary operations on them.
+
 v0.5.13
 -------
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -165,11 +165,14 @@ onto new grids.
 #### Mathematical operations
 
 `OutputVar`s support the usual mathematical operations. For instance, if
-`ts_max` is an `OutputVar`, `2 * ts_max` will be an `OutputVar` with doubled values.
+`ts_max` is an `OutputVar`, `2 * ts_max` will be an `OutputVar` with doubled
+values.
 
 For binary operations (e.g., `+, -, *, /`), `ClimaAnalysis` will check if the
 operation is well defined (i.e., the two variables are defined on the physical
-space). Binary operations do remove some attribute information.
+space). Binary operations do remove some attribute information. If two
+`OutputVar`s share the same start date, then the start date will remain in the
+resulting `OutputVar`s after performing binary operations on them.
 
 #### `Visualize`
 

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2348,6 +2348,16 @@ macro overload_binary_op(op)
                 end
             end
 
+            keep_attributes = ("start_date",)
+
+            for attr in keep_attributes
+                if haskey(x.attributes, attr) &&
+                   haskey(y.attributes, attr) &&
+                   x.attributes[attr] == y.attributes[attr]
+                    ret_attributes[attr] = x.attributes["start_date"]
+                end
+            end
+
             ret_dims = x.dims
             ret_dim_attributes = x.dim_attributes
 
@@ -2372,6 +2382,14 @@ macro overload_binary_op(op)
                 end
             end
 
+            keep_attributes = ("start_date",)
+
+            for attr in keep_attributes
+                if haskey(x.attributes, attr)
+                    ret_attributes[attr] = x.attributes[attr]
+                end
+            end
+
             ret_dims = deepcopy(x.dims)
             ret_dim_attributes = deepcopy(x.dim_attributes)
 
@@ -2393,6 +2411,14 @@ macro overload_binary_op(op)
                 if haskey(y.attributes, attr)
                     ret_attributes[attr] =
                         string(x, " ", string($op), " ", y.attributes[attr])
+                end
+            end
+
+            keep_attributes = ("start_date",)
+
+            for attr in keep_attributes
+                if haskey(y.attributes, attr)
+                    ret_attributes[attr] = y.attributes[attr]
                 end
             end
 

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -216,7 +216,12 @@ end
         "lon" => Dict("b" => 2),
         "lat" => Dict("a" => 1),
     ])
-    attribs = Dict("short_name" => "bob", "long_name" => "hi")
+    attribs = Dict(
+        "short_name" => "bob",
+        "long_name" => "hi",
+        "start_date" => "2008",
+        "cool" => "rad",
+    )
     var1 = ClimaAnalysis.OutputVar(attribs, dims, dim_attributes, data1)
 
     dim_attributes2 = OrderedDict([
@@ -228,7 +233,12 @@ end
     var2 = ClimaAnalysis.OutputVar(attribs, dims, dim_attributes2, data1)
 
     data3 = 5.0 .+ collect(reshape(1.0:(91 * 181 * 11), (11, 181, 91)))
-    attribs3 = Dict("long_name" => "bob", "short_name" => "bula")
+    attribs3 = Dict(
+        "long_name" => "bob",
+        "short_name" => "bula",
+        "start_date" => "2008",
+        "cool" => "not rad",
+    )
     var3 = ClimaAnalysis.OutputVar(attribs3, dims, dim_attributes, data3)
 
     # Check arecompatible
@@ -241,6 +251,11 @@ end
     @test ClimaAnalysis.short_name(var1plus10) == "bob + 10"
     @test ClimaAnalysis.long_name(var1plus10) == "hi + 10"
     @test var1plus10((0.0, 0.0, 0.0)) == var1((0.0, 0.0, 0.0)) + 10
+    @test var1plus10.attributes == Dict(
+        "short_name" => "bob + 10",
+        "long_name" => "hi + 10",
+        "start_date" => "2008",
+    )
 
     tenplusvar1 = 10 + var1
 
@@ -254,6 +269,11 @@ end
     @test var1plusvar3.data == data1 .+ data3
     @test ClimaAnalysis.short_name(var1plusvar3) == "bob + bula"
     @test ClimaAnalysis.long_name(var1plusvar3) == "hi + bob"
+    @test var1plusvar3.attributes == Dict(
+        "short_name" => "bob + bula",
+        "long_name" => "hi + bob",
+        "start_date" => "2008",
+    )
 
     # Test for element wise multiplication and division between OutputVars
     var_times = var1 * var3


### PR DESCRIPTION
~~This PR changes the behavior of doing binary operations with `OutputVar`s and reals. When doing binary operations between two `OutputVar`s, all attributes that are the same between the two `OutputVar`s are kept. Similarly, for any binary operation between an `OutputVar` and a real, all attributes are kept.~~

~~This may lead to incorrect information in the `OutputVar`. An example in the documentation showcases this.~~

~~Another approach to this if we don't want the attributes to be incorrect is to be more restrictive in what attributes are kept. For example, only the start date in addition to the short and long name will be kept.~~

I changed this PR to only keep the start date instead of including all possible attributes since those attributes can be wrong.

closes #220 