### PR TITLE
Make `slice` and `window` smarter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@ v0.5.17
 resampling may produce incorrect results when interpolating outside of the longitude range.
 This is fixed in this release.
 
+## More flexible `slice` and `window`
+
+Now, `slice` and `window` will try to match the name of the dimension with a
+database of known names. For example, they understand `lat` even if the data has
+dimensions `latitude`.
+
 v0.5.16
 -------
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -61,6 +61,7 @@ Var.has_altitude
 Var.has_pressure
 Var.conventional_dim_name
 Var.find_corresponding_dim_name
+Var.find_corresponding_dim_name_in_var
 Var.dim_units
 Var.range_dim
 Var.reordered_as

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -242,3 +242,41 @@ function find_corresponding_dim_name(dim_name::AbstractString, dim_names)
         error("Cannot find corresponding dimension for $dim_name in $dim_names")
     return dim_names[corresponding_dim_name]
 end
+
+"""
+    find_corresponding_dim_name(dim_name::AbstractString, var)
+
+Find the corresponding dimension name in `var`'s dimension that matches `dim_name`.
+
+Two names for a dimension match if both correspond to the same conventional name
+as determined by `Var.conventional_dim_name`.
+
+If nothing matches, return an error.
+
+This function is useful to identify a dimension from a given name, even if it is
+not its conventional name (e.g., `lat` vs `latitude`).
+
+Example
+==========
+
+```julia-repl
+julia> keys(var.dims)
+("lon", "lat", "time", "potatoes")
+
+julia> ClimaAnalysis.Var.find_corresponding_dim_name_in_var("t", var)
+"time"
+
+julia> ClimaAnalysis.Var.find_corresponding_dim_name("potatoes", var)
+"potatoes"
+```
+"""
+function find_corresponding_dim_name_in_var(dim_name::AbstractString, var)
+    dim_name_in_var = try
+        find_corresponding_dim_name(dim_name, keys(var.dims))
+    catch
+        dim_name
+    end
+    haskey(var.dims, dim_name_in_var) ||
+        error("Var does not have dimension $dim_name, found $(keys(var.dims))")
+    return dim_name_in_var
+end

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -816,6 +816,11 @@ end
 
     @test t_sliced.attributes["slice_time"] == "110.0"
     @test t_sliced.attributes["slice_time_units"] == "s"
+
+    # Test with different name for time
+    t_sliced_other_name = ClimaAnalysis.slice(var, t = 200.0)
+    @test t_sliced_other_name.attributes == t_sliced.attributes
+    @test t_sliced_other_name.data == t_sliced.data
 end
 
 @testset "Windowing" begin
@@ -847,6 +852,11 @@ end
     @test var_windowed.data == expected_data
 
     @test var_windowed.dims["time"] == time[3:6]
+
+    # Test with different name for time
+    var_windowed_t = ClimaAnalysis.window(var, "t", left = 2.5, right = 5.1)
+    @test var_windowed_t.attributes == var_windowed.attributes
+    @test var_windowed_t.data == var_windowed.data
 end
 
 @testset "Extracting dimension" begin


### PR DESCRIPTION
This commit extends `slice` and `window` so that they can detect and recognized "improperly" named dimensions. For example, if a file has dimension of `lon`, now the functions will work with `lon`, `long`, or `longitude`.