### PR TITLE
Add support for dates in `slice` and `window`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,23 @@ Now, `slice` and `window` will try to match the name of the dimension with a
 database of known names. For example, they understand `lat` even if the data has
 dimensions `latitude`.
 
+`slice` and `window` can also now work directly with `Dates.DateTime`s (assuming
+that the `OutputVar` contains enough information to convert from `times` to
+`dates`, namely the `start_date` among the attributes).
+
+Example
+```julia
+# Suppose `var` is an `OutputVar`
+julia> var.attributes["start_date"]
+2008-01-01T00:00:00
+
+julia> time_name(var)
+"t"
+
+# Notice how we call `time` and not `t`. This was not previously possible!
+julia> slice(var, time = Dates.DateTime(2009, 12, 15))
+```
+
 v0.5.16
 -------
 

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -30,6 +30,11 @@ reduced_var = window(var, "time", left = 10, right = 100)
 
 Now, you can apply the usual average functions.
 
+!!! note Did you know?
+
+    Did you know that when you are applying `window` on a temporal dimension, you
+    can also pass `Dates.DateTime` bounds? (E.g., `left = Dates.DateTime(2008)`).
+
 ## How do I take a global average over both the longitude and latitude dimensions?
 
 You can use `average_lonlat` to compute the global average over the longitude

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -639,7 +639,7 @@ end
 """
     remake(var; attributes, dims, dim_attributes, data)
 
-remake a `OutputVar`. If a keyword argument is not supplied, then it defaults
+Remake an `OutputVar`. If a keyword argument is not supplied, then it defaults
 to `attributes`, `dims`, `dim_attributes`, or `data` of `var`.
 """
 function remake(
@@ -1024,7 +1024,7 @@ If not available, return an empty string.
 function dim_units(var::OutputVar, dim_name)
     !haskey(var.dims, dim_name) &&
         error("Var does not have dimension $dim_name, found $(keys(var.dims))")
-    # Double get because var.dim_attributes is a dictionry whose values are dictionaries
+    # Double get because var.dim_attributes is a dictionary whose values are dictionaries
     string(get(get(var.dim_attributes, dim_name, Dict()), "units", ""))
 end
 

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -821,6 +821,21 @@ end
     t_sliced_other_name = ClimaAnalysis.slice(var, t = 200.0)
     @test t_sliced_other_name.attributes == t_sliced.attributes
     @test t_sliced_other_name.data == t_sliced.data
+
+    # Test with Dates.DateTime
+
+    var_with_start_date = copy(var)
+    push!(var_with_start_date.attributes, "start_date" => "2001-1-1")
+    t_sliced_dates = ClimaAnalysis.slice(
+        var_with_start_date,
+        t = Dates.DateTime(2001) + Dates.Second(200),
+    )
+    @test t_sliced.data == t_sliced_dates.data
+    # Dimension is not time
+    @test_throws ErrorException ClimaAnalysis.slice(
+        var_with_start_date,
+        z = Dates.DateTime(2001),
+    )
 end
 
 @testset "Windowing" begin
@@ -857,6 +872,33 @@ end
     var_windowed_t = ClimaAnalysis.window(var, "t", left = 2.5, right = 5.1)
     @test var_windowed_t.attributes == var_windowed.attributes
     @test var_windowed_t.data == var_windowed.data
+
+    # Windowing with Dates.DateTime
+
+    # First, `start_date` not available
+    @test_throws ErrorException ClimaAnalysis.window(
+        var,
+        "time",
+        left = Dates.DateTime(2001),
+    )
+
+    # Now with a valid start date
+    var_with_start_date = copy(var)
+    push!(var_with_start_date.attributes, "start_date" => "2001-1-1")
+    var_windowed_dates = ClimaAnalysis.window(
+        var_with_start_date,
+        "time",
+        left = Dates.DateTime(2001, 1, 1, 0, 0, 2, 500),
+        right = Dates.DateTime(2001, 1, 1, 0, 0, 5, 100),
+    )
+    @test var_windowed.data == var_windowed_dates.data
+
+    # Dates with a dimension that is not time
+    @test_throws ErrorException ClimaAnalysis.window(
+        var,
+        "z",
+        left = Dates.DateTime(2001),
+    )
 end
 
 @testset "Extracting dimension" begin


### PR DESCRIPTION
`slice` and `window` are very commonly used functions. One of the main use cases it selecting a moment of time to plot, or a subset of data to analyze.

When working with real observations, it is often very convenient to operate at the level of dates, instead of simulation time. This PR adds support for this feature.

Now, the following operations are supported
```julia
slice(var, time = Dates.DateTime(2009, 12, 15))
window(var, left = Dates.DateTime(2009, 12, 15), right = Dates.DateTime(2009, 12, 17))
```

The requirement for this is that `var` contains a `start_date` among its attributes. We also assume that the units of `time` are second.
