### PR TITLE
Add support for more operations on `OutputVar`s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@ v0.5.17
 resampling may produce incorrect results when interpolating outside of the longitude range.
 This is fixed in this release.
 
+## Support for more binary and unary operations
+
+`OutputVar`s can now be directly manipulated with additional operations,
+including `sqrt`, `min`, `log`, `-`.
+
 ## More flexible `slice` and `window`
 
 Now, `slice` and `window` will try to match the name of the dimension with a

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -174,6 +174,9 @@ space). Binary operations do remove some attribute information. If two
 `OutputVar`s share the same start date, then the start date will remain in the
 resulting `OutputVar`s after performing binary operations on them.
 
+Unary operations are supported to, for example `log(max(var, 1e-8))` returns a
+new `OutputVar` with the functions applied to the data.
+
 #### `Visualize`
 
 We can directly visualize `OutputVar`s.

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2493,7 +2493,7 @@ macro overload_binary_op(op)
                 if haskey(x.attributes, attr) &&
                    haskey(y.attributes, attr) &&
                    x.attributes[attr] == y.attributes[attr]
-                    ret_attributes[attr] = x.attributes["start_date"]
+                    ret_attributes[attr] = x.attributes[attr]
                 end
             end
 

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2581,6 +2581,7 @@ end
 @overload_binary_op (*)
 @overload_binary_op (/)
 
+include("outvar_operators.jl")
 include("outvar_dimensions.jl")
 include("constants.jl")
 

--- a/src/outvar_operators.jl
+++ b/src/outvar_operators.jl
@@ -1,0 +1,182 @@
+"""
+    overload_binary_op(op)
+
+Add methods to overload the given binary `op`erator for `OutputVars` and `Real`s.
+
+Attributes that are not `short_name`, `long_name`, are discarded in the process.
+"""
+macro overload_binary_op(op)
+    quote
+        function Base.$op(x::OutputVar, y::OutputVar)
+            arecompatible(x, y) || error("Input OutputVars are not compatible")
+
+            ret_attributes = Dict{String, Any}()
+
+            specific_attributes = ("short_name", "long_name")
+
+            for attr in specific_attributes
+                if haskey(x.attributes, attr) && haskey(y.attributes, attr)
+                    ret_attributes[attr] = string(
+                        x.attributes[attr],
+                        " ",
+                        string($op),
+                        " ",
+                        y.attributes[attr],
+                    )
+                end
+            end
+
+            keep_attributes = ("start_date",)
+
+            for attr in keep_attributes
+                if haskey(x.attributes, attr) &&
+                   haskey(y.attributes, attr) &&
+                   x.attributes[attr] == y.attributes[attr]
+                    ret_attributes[attr] = x.attributes[attr]
+                end
+            end
+
+            ret_dims = x.dims
+            ret_dim_attributes = x.dim_attributes
+
+            ret_data = @. $op(x.data, y.data)
+
+            return OutputVar(
+                ret_attributes,
+                ret_dims,
+                ret_dim_attributes,
+                ret_data,
+            )
+        end
+        function Base.$op(x::OutputVar, y::Real)
+            ret_attributes = empty(x.attributes)
+
+            specific_attributes = ("short_name", "long_name")
+
+            for attr in specific_attributes
+                if haskey(x.attributes, attr)
+                    ret_attributes[attr] =
+                        string(x.attributes[attr], " ", string($op), " ", y)
+                end
+            end
+
+            keep_attributes = ("start_date",)
+
+            for attr in keep_attributes
+                if haskey(x.attributes, attr)
+                    ret_attributes[attr] = x.attributes[attr]
+                end
+            end
+
+            ret_dims = deepcopy(x.dims)
+            ret_dim_attributes = deepcopy(x.dim_attributes)
+
+            ret_data = @. $op(x.data, y)
+
+            return OutputVar(
+                ret_attributes,
+                ret_dims,
+                ret_dim_attributes,
+                ret_data,
+            )
+        end
+        function Base.$op(x::Real, y::OutputVar)
+            ret_attributes = empty(y.attributes)
+
+            specific_attributes = ("short_name", "long_name")
+
+            for attr in specific_attributes
+                if haskey(y.attributes, attr)
+                    ret_attributes[attr] =
+                        string(x, " ", string($op), " ", y.attributes[attr])
+                end
+            end
+
+            keep_attributes = ("start_date",)
+
+            for attr in keep_attributes
+                if haskey(y.attributes, attr)
+                    ret_attributes[attr] = y.attributes[attr]
+                end
+            end
+
+            ret_dims = deepcopy(y.dims)
+            ret_dim_attributes = deepcopy(y.dim_attributes)
+
+            ret_data = @. $op(x, y.data)
+
+            return OutputVar(
+                ret_attributes,
+                ret_dims,
+                ret_dim_attributes,
+                ret_data,
+            )
+        end
+    end
+end
+
+@overload_binary_op (+)
+@overload_binary_op (-)
+@overload_binary_op (*)
+@overload_binary_op (/)
+@overload_binary_op max
+@overload_binary_op min
+
+"""
+    @overload_unary_op op
+
+Generate a method to overload the unary operator `op` for `OutputVar`.
+
+Handles attributes `short_name`, `long_name`: Prepends the operator name, e.g., "log(Temperature)".
+"""
+macro overload_unary_op(op)
+    esc(
+        quote
+            function Base.$op(x::OutputVar)
+                # Start by copying all attributes from x
+                ret_attributes = Dict{String, Any}()
+
+                # Modify specific attributes like names
+                specific_attributes = ("short_name", "long_name")
+                for attr in specific_attributes
+                    if haskey(x.attributes, attr)
+                        # Prepend the operator name
+                        ret_attributes[attr] =
+                            string($(string(op)), "(", x.attributes[attr], ")")
+                    end
+                end
+
+                keep_attributes = ("start_date",)
+                for attr in keep_attributes
+                    if haskey(x.attributes, attr)
+                        ret_attributes[attr] = x.attributes[attr]
+                    end
+                end
+
+                # Keep dimensions and their attributes (use deepcopy for safety)
+                ret_dims = deepcopy(x.dims)
+                ret_dim_attributes = deepcopy(x.dim_attributes)
+
+                # Perform operation element-wise
+                ret_data = @. $op(x.data)
+
+                return OutputVar(
+                    ret_attributes,
+                    ret_dims,
+                    ret_dim_attributes,
+                    ret_data,
+                )
+            end
+        end,
+    )
+end
+
+@overload_unary_op log
+@overload_unary_op log2
+@overload_unary_op log10
+@overload_unary_op exp
+@overload_unary_op sin
+@overload_unary_op cos
+@overload_unary_op tan
+@overload_unary_op sqrt
+@overload_unary_op (-) # Unary minus


### PR DESCRIPTION
This commit adds support for more operations that act directly on `OutputVar`s, including `-`, `max`, `log`.

Closes #246
