### PR TITLE
Bump to 0.5.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAnalysis"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
-version = "0.5.16"
+version = "0.5.17"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
Bump to version 0.5.17. Mostly to get the updated slice/window functions to the calibration pipelines.