### PR TITLE
Add support for variadic `get` for `SimDir`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,14 @@ This is fixed in this release.
 `OutputVar`s can now be directly manipulated with additional operations,
 including `sqrt`, `min`, `log`, `-`.
 
+## Variadic `get` for `SimDir`
+
+`get` can now be used to fetch multiple variables at the same time. For example
+```julia
+ta, va, ua = get(simdir, "ta", "va", "ua")
+```
+This works only if the variables are fully identified by their short name.
+
 ## More flexible `slice` and `window`
 
 Now, `slice` and `window` will try to match the name of the dimension with a

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -68,7 +68,11 @@ ts_max = get(simdir; short_name = "ts", reduction = "max", period = "3.0h")
 `ts_max` is a ` OutputVar`, a type that contains the variable as well as some
 metadata. When there is only one combination `short_name/reduction/period`, the
 function `get` can be used with `get(simdir, short_name)` (e.g., `get(simdir,
-"orog")` in the previous example).
+"orog")` in the previous example). In this case, you can get multiple variables
+at the same time with
+```julia
+orog, ua, va = get(simdir, "orog", "ua", "va")
+```
 
 If there are more files with the same combination of short name, reduction, and
 period, then the function `get` automatically stitch the `.nc` files together

--- a/src/Sim.jl
+++ b/src/Sim.jl
@@ -201,13 +201,18 @@ function get(
 end
 
 """
-    get(simdir::SimDir, short_name)
+    get(simdir::SimDir, short_names...)
 
-If only one reduction and period exist for `short_name`, return the corresponding
-`OutputVar`.
+If only one reduction and period exist for the given `short_name`s, return the corresponding
+`OutputVar`s.
 """
-function get(simdir::SimDir, short_name::String)
-    return get(simdir; short_name, reduction = nothing, period = nothing)
+function get(simdir::SimDir, short_names...)
+    results = map(
+        short_name ->
+            get(simdir; short_name, reduction = nothing, period = nothing),
+        short_names,
+    )
+    return length(results) == 1 ? first(results) : results
 end
 
 """

--- a/test/test_Sim.jl
+++ b/test/test_Sim.jl
@@ -124,6 +124,11 @@ end
           get(simdir; short_name = "orog", reduction = "inst", period = nothing)
     @test ts_max == get(simdir; short_name = "ts", reduction = "max")
 
+    # Test `get` with multiple arguments
+    orog2, pfull2 = get(simdir, "orog", "pfull")
+    @test orog == orog2
+    @test pfull == pfull2
+
     # short_name, long_name, units
     @test ClimaAnalysis.short_name(orog) == "orog"
     @test ClimaAnalysis.long_name(orog) == "Surface Altitude, Instantaneous"


### PR DESCRIPTION
It's common to `get` multiple variables at the same time. This commit simplifies this process.

Instead of
```julia
lhf = get(simdir; short_name = "lhf")
shf = get(simdir; short_name = "shf")
swu = get(simdir; short_name = "swu")
```

We can now write
```julia
lhf, shf, swu = get(simdir, "lhf", "shf", "swu")
```
