### PR TITLE
Support resampling with only one OutputVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,16 @@ along the longitude, latitude, or time dimension respectively.
 In addition to `reordered_as`, there is also `permutedims(var, perm)` which permute the
 dimensions of an `OutputVar` according to `perm`, an iterable of dimension names.
 
+## Resample with keyword arguments of dimension name and array
+
+You can now resample without needing another `OutputVar` to resample on. Note
+that checking for units is not done. See the example below.
+
+```julia
+resampled_var = resampled_as(src_var, long = [0.0, 1.0], lat = [2.0, 3.0])
+```
+
+
 v0.5.16
 -------
 

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -215,6 +215,20 @@ partial_resampled_var.data
 partial_resampled_var.dims
 ```
 
+## How do I resample without needing another `OutputVar`?
+
+You can resample by passing keyword arguments of the dimension name and the
+vectors to resample on. See the example below.
+
+```@repl resampled_as
+src_var.data
+src_var.dims
+resampled_var =
+    ClimaAnalysis.resampled_as(src_var, long = [0.0, 1.0], lat = [0.0, 1.0, 2.0]);
+resampled_var.data
+resampled_var.dims
+```
+
 ## How do I apply a land or sea mask to a `OutputVar`?
 
 You can use `apply_landmask` or `apply_oceanmask` to mask out the land or ocean,

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1732,7 +1732,12 @@ Resample `data` in `src_var` to `dims` in `dest_var` over all dimensions.
 Reordering is automatically done.
 """
 function _resampled_as_all(src_var::OutputVar, dest_var::OutputVar)
-    src_var = reordered_as(src_var, dest_var)
+    conventional_names_src = collect(conventional_dim_name.(keys(src_var.dims)))
+    conventional_names_dest =
+        collect(conventional_dim_name.(keys(dest_var.dims)))
+    if conventional_names_src != conventional_names_dest
+        src_var = reordered_as(src_var, dest_var)
+    end
 
     itp = _make_interpolant(src_var.dims, src_var.data)
     src_resampled_data =

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -1696,6 +1696,11 @@ end
     @test resampled_var.data == reshape(1.0:(181 * 91), (181, 91))[1:91, 1:46]
     @test_throws BoundsError ClimaAnalysis.resampled_as(dest_var, src_var)
 
+    # Test if reordering is automatically done
+    src_var_transpose = permutedims(src_var, ("latitude", "longitude"))
+    resampled_var = ClimaAnalysis.resampled_as(src_var_transpose, dest_var)
+    @test resampled_var.data == reshape(1.0:(181 * 91), (181, 91))[1:91, 1:46]
+
     # Test with ordered iterable for dims
     resampled_var =
         ClimaAnalysis.resampled_as(src_var, long = dest_long, lat = dest_lat)


### PR DESCRIPTION
closes #257 - This PR adds resampling without needing to construct an entire `OutputVar` for `dest_var`

## TODO

- [x] Fix minor bug where if the units of any dimension in `src_var` is missing, then resampling is not possible. 