### PR TITLE
Add Base.cat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,18 @@
 ClimaAnalysis.jl Release Notes
 ===============================
+v0.5.18
+-------
+
+## Concatenation of OutputVars
+
+You can concatenate `OutputVar`s along a single dimension. This function is helpful if you
+need to concatenate `OutputVar`s after applying `split_by_season_across_time` or `window`.
+
+```julia
+seasons = ClimaAnalysis.split_by_season_across_time(var);
+DJF = cat(seasons[begin:4:end]..., dim = "time");
+```
+
 v0.5.17
 -------
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -90,6 +90,7 @@ Var.apply_landmask
 Var.apply_oceanmask
 Var.make_lonlat_mask
 Base.replace(var::OutputVar, old_new::Pair...)
+Base.cat(vars::OutputVar...; dim::String)
 Var.reverse_dim
 Var.reverse_dim!
 Base.show(io::IO, var::OutputVar)

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1095,8 +1095,7 @@ Return the `units` of the given `dim_name` in `var`, if available.
 If not available, return an empty string.
 """
 function dim_units(var::OutputVar, dim_name)
-    !haskey(var.dims, dim_name) &&
-        error("Var does not have dimension $dim_name, found $(keys(var.dims))")
+    dim_name = find_corresponding_dim_name_in_var(dim_name, var)
     # Double get because var.dim_attributes is a dictionary whose values are dictionaries
     string(get(get(var.dim_attributes, dim_name, Dict()), "units", ""))
 end


### PR DESCRIPTION
closes #264 - This PR adds `Base.cat` for `OutputVar`s and also make `dim_units` agnostic to the name of the dimension.

Only the start date, sort name, and units are preserved are kept in the resulting `OutputVar`.