### PR TITLE
Add FlatVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,25 @@ seasons = ClimaAnalysis.split_by_season_across_time(var);
 DJF = cat(seasons[begin:4:end]..., dim = "time");
 ```
 
+## FlatVar
+
+You can now flatten `data` of `OutputVar`s using `ClimaAnalysis.flatten` and `ClimaAnalysis.unflatten`.
+Flattening data gives `FlatVar` whose flattened data can be accessed with `flat_var.data` and the metadata
+can be accessed with `flat_var.metadata`. Then, unflattening data reconstructs the original `OutputVar`.
+This feature is helpful with preparing data for use in other pipelines.
+
+```julia
+flat_var = ClimaAnalysis.flatten(var)
+
+# Flattened data and metadata can be accessed like this
+flat_var.data
+flat_var.metadata
+
+# Reconstructing the original OutputVar
+unflattened_var = ClimaAnalysis.unflatten(flat_var)
+unflattened_var = ClimaAnalysis.unflatten(flat_var.metadata, flat_var.data)
+```
+
 v0.5.17
 -------
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -32,6 +32,7 @@ makedocs(;
         "Visualizing OutputVars" => "visualize.md",
         "RMSEVariables" => "rmse_var.md",
         "Visualizing RMSEVariables" => "visualize_rmse_var.md",
+        "FlatVar" => "flat.md",
         "APIs" => "api.md",
         "How do I?" => "howdoi.md",
     ],

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -96,6 +96,16 @@ Var.reverse_dim!
 Base.show(io::IO, var::OutputVar)
 ```
 
+## FlatVar
+
+```@docs
+Var.Metadata
+Var.FlatVar
+Var.flatten
+Var.unflatten
+Var.flatten_dim_order
+```
+
 ## Leaderboard
 ```@docs
 Leaderboard.RMSEVariable

--- a/docs/src/flat.md
+++ b/docs/src/flat.md
@@ -1,0 +1,97 @@
+# `FlatVar`
+
+To help with data preparation and feeding data from `OutputVar`s into other pipelines,
+ClimaAnalysis provides two functions [`flatten`](@ref) to flatten an `OutputVar` into a
+`FlatVar` and [`unflatten`](@ref) to unflatten a `FlatVar` into an `OutputVar`. A `FlatVar`
+consists of `data` which is a one-dimensional vector of the `OutputVar`'s data and
+`metadata` which contain all the necessary information to reconstruct the original
+`OutputVar`.
+
+The problems that `FlatVar` aim to solve are
+
+1. Flattening can be error prone if one does not keep track of the ordering of the
+   dimensions,
+2. Flattening a one-dimensional vector loses important information, such as what quantity is
+   represented by the `OutputVar` and the ordering of the dimensions.
+
+## Flatten
+
+To solve the first problem, ClimaAnalysis enforces the ordering of the dimensions when
+flattening to be `("longitude", "latitude", "pressure", "altitude", "time")` and omits the
+dimensions that do not exist in the `OutputVar`.
+
+```@setup flat
+import ClimaAnalysis
+import OrderedCollections: OrderedDict
+
+time = [0.0, 1.0, 5.0]
+lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+lat = [-90.0, -30.0, 30.0, 90.0]
+n_elts = length(lat) * length(lon) * length(time)
+dims = OrderedDict("time" => time, "lon" => lon, "lat" => lat)
+size_of_data = (length(time), length(lon), length(lat))
+data = reshape(collect(1.0:n_elts), size_of_data...)
+attribs = Dict("short_name" => "pr")
+dim_attribs = OrderedDict(
+    "time" => Dict("units" => "s"),
+    "lon" => Dict("units" => "degrees_east"),
+    "lat" => Dict("units" => "degrees_north"),
+)
+var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+
+# Construct an OutputVar with 3 NaNs
+nan_data = copy(data)
+nan_data[1,1,1] = NaN
+nan_data[2,1,3] = NaN
+nan_data[3,5,4] = NaN
+nan_var = ClimaAnalysis.remake(var, data = nan_data)
+```
+
+The example below demonstrates how the order of the dimensions of a `OutputVar` does
+not matter when flattening the data. The order of dimensions of `flat_var` is
+`time`, `lon`, and `lat`, and the order of dimensions of `permuted_var` is `lon`, `lat`, and
+`time`. When both `OutputVar`s are flattened, the flattened data of both `OutputVar`s are
+the same. As such, using `flatten` removes the need to keep track of the order of the
+dimensions of a `OutputVar`.
+
+```@repl flat
+var
+flat_var = ClimaAnalysis.flatten(var);
+permuted_var = permutedims(var, ("longitude", "latitude", "time"));
+flat_permuted_var = ClimaAnalysis.flatten(permuted_var);
+isequal(flat_permuted_var.data, flat_var.data)
+```
+
+The data can be extracted by `flat_var.data` and the metadata can be extracted by
+`flatvar.metadata`. More information about the metadata will discussed in the section below.
+
+Furthermore, if `ignore_nan = true`, then `NaNs` are excluded when flattening the data.
+
+```@repl flat
+count(isnan, nan_var.data) # nan_var is the same as var, but contains three NaNs
+flat_nan_var = ClimaAnalysis.flatten(nan_var, ignore_nan = true); # default is true
+length(flat_nan_var.data)
+```
+
+## Unflatten
+
+To solve the second problem, there is the `metadata` field in `FlatVar` that stores the
+necessary information to fully reconstruct the `OutputVar`. With `unflatten`, one can
+call `unflatten` on both `FlatVar` or on `metadata` and `data` to reconstruct the
+`OutputVar`. This decoupling of `metadata` and `data` also means that one needs to be
+careful that the correct `metadata` and `data` are being used to reconstruct the
+`Outputvar`.
+
+See the example below of unflattening `flat_var`.
+
+```@repl flat
+unflatten_var = ClimaAnalysis.unflatten(flat_var)
+isequal(unflatten_var.data, var.data)
+```
+
+One can also unflatten using the metadata and data of `flat_var`.
+
+```@repl flat
+unflatten_var = ClimaAnalysis.unflatten(flat_var.metadata, flat_var.data)
+isequal(unflatten_var.data, var.data)
+```

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2835,5 +2835,6 @@ end
 include("outvar_operators.jl")
 include("outvar_dimensions.jl")
 include("constants.jl")
+include("flat.jl")
 
 end

--- a/src/flat.jl
+++ b/src/flat.jl
@@ -1,0 +1,195 @@
+export flatten, unflatten, flatten_dim_order
+
+"""
+    Representing the metadata of an `OutputVar` and contain all the necessary
+    information to reconstruct an `OutputVar`.
+"""
+struct Metadata{T <: AbstractArray, B, C, I <: Integer}
+    "Attributes associated to this variable, such as short/long name"
+    attributes::Dict{String, B}
+
+    "Dimensions over which the variable is defined"
+    dims::OrderedDict{String, T}
+
+    "Attributes associated to the dimensions"
+    dim_attributes::OrderedDict{String, C}
+
+    "Order of dimensions when flattening the data of the OutputVar"
+    ordered_dims::Tuple{Vararg{String}}
+
+    "Indices of NaNs in data"
+    nan_indices::Vector{I}
+end
+
+"""
+    Representing a flat output variable
+"""
+struct FlatVar{A <: AbstractVector}
+    "Metadata associated with the OutputVar"
+    metadata::Metadata
+
+    "Vector that contains all the data"
+    data::A
+end
+
+"""
+    flatten(var::OutputVar;
+            dims = ("longitude", "latitude", "pressure_level", "z", "time"),
+            ignore_nan = true)
+
+Flatten `var` into a `FlatVar` according to the ordering `dims`.
+
+The default order of dimensions for flattening is 
+`("longitude", "latitude", "pressure_level", "z", "time")`. Dimensions not present in `var`
+are excluded from this ordering.
+
+If `ignore_nan = true`, then `NaNs` are excluded from the flattened data. Otherwise, `NaN`s
+are included.
+"""
+function flatten(
+    var::OutputVar;
+    dims = ("longitude", "latitude", "pressure_level", "z", "time"),
+    ignore_nan = true,
+)
+
+    # Filter unnecessary dimension names
+    dims = conventional_dim_name.(dims)
+    var_dims = conventional_dim_name.(collect(keys(var.dims)))
+    dims = Tuple(
+        find_corresponding_dim_name_in_var(dim, var) for
+        dim in dims if dim in var_dims
+    )
+
+    # Check that all dimensions are present
+    length(dims) == length(var.dims) || error(
+        "All the dimensions in var ($(keys(var.dims))) are not present in dims ($dims)",
+    )
+
+    # To flatten data, we need to permute, vectorize, and remove NaNs
+    # Permute and vectorize data
+    perm = Tuple(indexin(dims, collect(keys(var.dims))))
+    permute_data = PermutedDimsArray(var.data, perm)
+    vec_data = vec(permute_data)
+
+    # Remove NaNs if necessary
+    if ignore_nan
+        nan_indices = findall(isnan, vec_data)
+        if !isempty(nan_indices)
+            valid_indices = setdiff(collect(eachindex(vec_data)), nan_indices)
+            vec_data = @view vec_data[valid_indices]
+        end
+    end
+
+    # Make metadata
+    metadata = Metadata(
+        deepcopy(var.attributes),
+        deepcopy(var.dims),
+        deepcopy(var.dim_attributes),
+        dims,
+        nan_indices,
+    )
+    return FlatVar(metadata, copy(vec_data))
+end
+
+"""
+    unflatten(var::FlatVar)
+
+Unflatten `var` and reconstruct the `OutputVar`.
+"""
+function unflatten(var::FlatVar)
+    return unflatten(var.metadata, var.data)
+end
+
+"""
+    unflatten(metadata::Metadata, data::AbstractVector)
+
+Unflatten `data` according the `metadata` and reconstruct the `OutputVar`.
+
+This function assumes that order of `data` before flattened is the same as
+`flatten_dim_order(metadata)`.
+"""
+function unflatten(metadata::Metadata, data::AbstractVector)
+    # Check length of data match the length of the dimensions in metadata
+    data_size = _data_size(metadata, ignore_nan = true)
+    length(data) == data_size || error(
+        "Flattened data should be of length $data_size; got length $(length(data))",
+    )
+
+    # To unflatten data, we need to remove NaNs, vectorize, and permute. Note that this is
+    # the operations of flattening data, but in reverse.
+    # Include NaNs
+    if !isempty(metadata.nan_indices)
+        data_length = values(metadata.dims) |> collect .|> length |> prod
+        nan_data = fill(zero(eltype(data)), data_length)
+        # NaN can be NaN32 or NaN64
+        nan_data[metadata.nan_indices] .= eltype(data)(NaN)
+        valid_indices = findall(!isnan, nan_data)
+        nan_data[valid_indices] = data
+        data = nan_data
+    end
+
+    # Reshape data
+    reshape_dims = (length(metadata.dims[dim]) for dim in metadata.ordered_dims)
+    data = reshape(data, reshape_dims...)
+
+    # Permute dimensions of data
+    dim2index = Dict([
+        dim_name => index for
+        (index, dim_name) in enumerate(keys(metadata.dims))
+    ])
+    perm = invperm(
+        collect(dim2index[dim_name] for dim_name in metadata.ordered_dims),
+    )
+    data = permutedims(data, perm)
+
+    return OutputVar(
+        deepcopy(metadata.attributes),
+        deepcopy(metadata.dims),
+        deepcopy(metadata.dim_attributes),
+        copy(data),
+    )
+end
+
+"""
+    flatten_dim_order(var::FlatVar)
+
+Return the order of the dimensions before flattening `data`.
+"""
+function flatten_dim_order(var::FlatVar)
+    return flatten_dim_order(var.metadata)
+end
+
+"""
+    flatten_dim_order(metadata::Metadata)
+
+Return the order of the dimensions before flattening `data`.
+"""
+function flatten_dim_order(metadata::Metadata)
+    return metadata.ordered_dims
+end
+
+"""
+    _data_size(var::FlatVar; ignore_nan = true)
+
+Get the length of `var.data`.
+
+If `ignore_nan = true`, then the length is computed excluding `NaN`s. If
+`ignore_nan = false`, then the length is computed including `NaN`s.
+"""
+function _data_size(var::FlatVar; ignore_nan = true)
+    return _data_size(var.metadata; ignore_nan = ignore_nan)
+end
+
+"""
+    _data_size(metadata::Metadata; ignore_nan = true)
+
+Get the length of the flattened `data` according to the `metadata`.
+
+If `ignore_nan = true`, then the length is computed excluding `NaN`s. If
+`ignore_nan = false`, then the length is computed including `NaN`s.
+"""
+function _data_size(metadata::Metadata; ignore_nan = true)
+    data_size_with_nans = prod(length.(values(metadata.dims)))
+    return ignore_nan ? data_size_with_nans - length(metadata.nan_indices) :
+           data_size_excluding_nans
+end

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -3444,6 +3444,119 @@ end
     )
 end
 
+@testset "FlatVar" begin
+    lat = [-90.0, -30.0, 30.0, 90.0]
+    lon = [-60.0, -30.0, 0.0, 30.0, 60.0]
+    time = [0.0, 1.0, 5.0]
+    n_elts = length(lat) * length(lon) * length(time)
+    dims = OrderedDict("lat" => lat, "lon" => lon, "time" => time)
+    size_of_data = (length(lat), length(lon), length(time))
+    data = reshape(collect(1.0:n_elts), size_of_data...)
+    attribs = Dict("long_name" => "hi")
+    dim_attribs = OrderedDict(
+        "lat" => Dict("units" => "degrees"),
+        "lon" => Dict("units" => "degrees"),
+        "time" => Dict("units" => "seconds"),
+    )
+    var = ClimaAnalysis.OutputVar(attribs, dims, dim_attribs, data)
+
+    flat_var =
+        ClimaAnalysis.Var.flatten(var, dims = ("latitude", "longitude", "t"))
+    @test ClimaAnalysis.Var.flatten_dim_order(flat_var) ==
+          ("lat", "lon", "time")
+    @test ClimaAnalysis.Var._data_size(flat_var) == n_elts
+    @test flat_var.data == vec(data)
+    @test flat_var.metadata.attributes == var.attributes
+    @test flat_var.metadata.dims == var.dims
+    @test flat_var.metadata.dim_attributes == var.dim_attributes
+    @test flat_var.metadata.ordered_dims == ("lat", "lon", "time")
+
+    unflatten_var = ClimaAnalysis.Var.unflatten(flat_var)
+    @test var.data == unflatten_var.data
+    @test var.attributes == unflatten_var.attributes
+    @test var.dim_attributes == unflatten_var.dim_attributes
+    @test var.dims == unflatten_var.dims
+
+    flat_var = ClimaAnalysis.Var.flatten(var)
+    @test ClimaAnalysis.Var.flatten_dim_order(flat_var) ==
+          ("lon", "lat", "time")
+    @test flat_var.data == vec(permutedims(data, (2, 1, 3)))
+    @test flat_var.metadata.attributes == var.attributes
+    @test flat_var.metadata.dims == var.dims
+    @test flat_var.metadata.dim_attributes == var.dim_attributes
+    @test flat_var.metadata.ordered_dims == ("lon", "lat", "time")
+
+    unflatten_var = ClimaAnalysis.Var.unflatten(flat_var)
+    @test var.data == unflatten_var.data
+    @test var.attributes == unflatten_var.attributes
+    @test var.dim_attributes == unflatten_var.dim_attributes
+    @test var.dims == unflatten_var.dims
+
+    # Test unflattening with different datas
+    flat_var = ClimaAnalysis.Var.flatten(var)
+    var2 = ClimaAnalysis.Var.remake(
+        var;
+        data = reshape(collect((-n_elts):-1), size_of_data...),
+    )
+    var2 = permutedims(var2, ("lon", "time", "lat"))
+    flat_var2 = ClimaAnalysis.Var.flatten(var2)
+    reconstructed_var =
+        ClimaAnalysis.Var.unflatten(flat_var.metadata, flat_var2.data)
+    reconstructed_var = permutedims(reconstructed_var, ("lon", "time", "lat"))
+    @test reconstructed_var.data == var2.data
+    @test reconstructed_var.attributes == var.attributes
+    @test reconstructed_var.dim_attributes == var.dim_attributes
+    @test reconstructed_var.dims == var.dims
+
+    # Test with NaNs
+    nan_data = reshape(collect(1.0:n_elts), size_of_data...)
+    nan_data[1, 1, 1] = NaN
+    nan_data[3, 2, 3] = NaN
+    var = ClimaAnalysis.remake(var, data = nan_data)
+    flat_var = ClimaAnalysis.Var.flatten(var)
+    @test ClimaAnalysis.Var.flatten_dim_order(flat_var) ==
+          ("lon", "lat", "time")
+    @test ClimaAnalysis.Var._data_size(flat_var) == n_elts - 2
+    @test flat_var.data == filter(!isnan, vec(permutedims(nan_data, (2, 1, 3))))
+    @test flat_var.metadata.attributes == var.attributes
+    @test flat_var.metadata.dims == var.dims
+    @test flat_var.metadata.dim_attributes == var.dim_attributes
+    @test flat_var.metadata.ordered_dims == ("lon", "lat", "time")
+
+    unflatten_var = ClimaAnalysis.Var.unflatten(flat_var)
+    @test isequal(var.data, unflatten_var.data)
+    @test var.attributes == unflatten_var.attributes
+    @test var.dim_attributes == unflatten_var.dim_attributes
+    @test var.dims == unflatten_var.dims
+
+    # Test unflattening with different NaN datas
+    data = reshape(collect((-n_elts):-1), size_of_data...)
+    nan_data[1, 1, 1] = NaN
+    nan_data[3, 2, 3] = NaN
+    var2 = ClimaAnalysis.Var.remake(var; data = nan_data)
+    var2 = permutedims(var2, ("lon", "time", "lat"))
+    flat_var2 = ClimaAnalysis.Var.flatten(var2)
+    reconstructed_var =
+        ClimaAnalysis.Var.unflatten(flat_var.metadata, flat_var2.data)
+    reconstructed_var = permutedims(reconstructed_var, ("lon", "time", "lat"))
+    @test isequal(reconstructed_var.data, var2.data)
+    @test reconstructed_var.attributes == var.attributes
+    @test reconstructed_var.dim_attributes == var.dim_attributes
+    @test reconstructed_var.dims == var.dims
+
+    # Missing dimensions
+    @test_throws ErrorException ClimaAnalysis.Var.flatten(
+        var,
+        dims = ("lat", "lon"),
+    )
+
+    # Length of data is not right
+    @test_throws ErrorException ClimaAnalysis.Var.unflatten(
+        flat_var.metadata,
+        [1.0, 2.0, 3.0],
+    )
+end
+
 @testset "Show" begin
     lat = collect(range(-89.5, 89.5, 180))
     lon = collect(range(-179.5, 179.5, 360))


### PR DESCRIPTION
closes #240 - This PR adds functionality to help with calibration by giving a consistent way of flattening an `OutputVar` without worrying about using `Base.permutedims` everywhere.

This is still a work in progress, because this has not been tested with any actual calibration attempt. Furthermore, there is still the question of how to handle operations where masking is needed.

For example, with ClimaLand calibration, you need to only consider points over land. Let say that you want to visualize the observations from the EKP object. As of now, there is not enough information to reconstruct the `OutputVar` without also keeping track of which values are `NaN`.