### PR TITLE
Add Var.average_seasons_across_time

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,22 @@ unflattened_var = ClimaAnalysis.unflatten(flat_var)
 unflattened_var = ClimaAnalysis.unflatten(flat_var.metadata, flat_var.data)
 ```
 
+## Seasonal average
+
+You can now compute seasonal averages with `average_season_across_time`. This returns
+a `OutputVar`, where the time dimension consists of the first date of each season, and the
+years and seasons can be accessed by `var.attributes["season"]` and `var.attributes["year"]`.
+
+```julia
+seasonal_averages_var = average_season_across_time(var)
+
+# Return a vector of seasons
+seasonal_averages_var.attributes["season"]
+
+# Return a vector of years
+seasonal_averages_var.attributes["year"]
+```
+
 ## Bug fixes
 
 - Fixed support for reductions when dimensions have only one point.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -79,6 +79,7 @@ Var.integrate_lat
 Var.integrate_lon
 Var.split_by_season(var::OutputVar)
 Var.split_by_season_across_time(var::OutputVar)
+Var.average_season_across_time
 Var.split_by_month(var::OutputVar)
 Var.bias
 Var.global_bias

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -346,6 +346,9 @@ function split_by_season_across_time(dates::AbstractArray{<:Dates.DateTime})
     # Find the first date of the season that first(dates) belongs in
     (first_season, first_year) = find_season_and_year(first(dates))
     season_to_month = Dict("MAM" => 3, "JJA" => 6, "SON" => 9, "DJF" => 12)
+    # Because the year is determined from the second month, we need to handle the case when
+    # the season is DJF
+    first_year = first_season == "DJF" ? first_year - 1 : first_year
     first_date_of_season =
         Dates.DateTime(first_year, season_to_month[first_season], 1)
 
@@ -431,8 +434,11 @@ Return a tuple of the year and season belong to `date`. The variable `year` is
 an integer and `season` is a string.
 
 The months of the seasons are March to May, June to August, September to
-November, and December to February. If a date is in December to February, the
-year is chosen to be the year that the season starts.
+November, and December to February.
+
+The year is determined by the second month of the season. For example, if the
+months are December 2009, January 2010, and February 2010, then the year of the
+season is 2010.
 """
 function find_season_and_year(date::Dates.DateTime)
     if Dates.Month(3) <= Dates.Month(date) <= Dates.Month(5)
@@ -442,10 +448,8 @@ function find_season_and_year(date::Dates.DateTime)
     elseif Dates.Month(9) <= Dates.Month(date) <= Dates.Month(11)
         return ("SON", Dates.year(date))
     else
-        # ambiguous what year should be used, so we use the convention that
-        # it is the year of December
         corrected_year =
-            Dates.month(date) == 12 ? Dates.year(date) : Dates.year(date) - 1
+            Dates.month(date) == 12 ? Dates.year(date) + 1 : Dates.year(date)
         return ("DJF", corrected_year)
     end
 end

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1989,8 +1989,12 @@ determined by the dates of the season. The return type is a vector of `OutputVar
 The months of the seasons are March to May (MAM), June to August (JJA), September to
 November (SON), and December to February (DJF). If there are no dates found for a season,
 then the `OutputVar` for that season will be an empty `OutputVar`. The first `OutputVar` is
-guaranteed to not be empty. For non-empty OutputVars, the season can be found by
+guaranteed to not be empty. For non-empty `OutputVar`s, the season can be found by
 `var.attributes["season"]`.
+
+Also, for non-empty `OutputVar`s, the year can be found by `var.attributes["year"]`. The
+convention used is that the second month of the season determines the year. For example, the
+year of DJF is the same year as Janauary.
 
 The function will use the start date in `var.attributes["start_date"]`. The unit of time is
 expected to be second.
@@ -1999,7 +2003,7 @@ This function differs from `split_by_season` as `split_by_season` splits dates b
 season and ignores that seasons can come from different years.
 """
 function split_by_season_across_time(var::OutputVar)
-    _check_time_dim(var::OutputVar)
+    _check_time_dim(var)
     start_date = Dates.DateTime(var.attributes["start_date"])
 
     seasons_across_year_dates =
@@ -2014,10 +2018,13 @@ function split_by_season_across_time(var::OutputVar)
 
     for var in split_by_season_vars
         if !isempty(var)
-            season, _ = find_season_and_year(
+            season, year = find_season_and_year(
                 first(time_to_date.(start_date, times(var))),
             )
+            # This override the attributes if the user sets something for season and year
+            # already
             var.attributes["season"] = season
+            var.attributes["year"] = string(year)
         end
     end
     return split_by_season_vars

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -107,8 +107,8 @@ end
 
 @testset "find season and year" begin
     dates = [Dates.DateTime(2010, i) for i in 1:12]
-    @test Utils.find_season_and_year(dates[1]) == ("DJF", 2009)
-    @test Utils.find_season_and_year(dates[2]) == ("DJF", 2009)
+    @test Utils.find_season_and_year(dates[1]) == ("DJF", 2010)
+    @test Utils.find_season_and_year(dates[2]) == ("DJF", 2010)
     @test Utils.find_season_and_year(dates[3]) == ("MAM", 2010)
     @test Utils.find_season_and_year(dates[4]) == ("MAM", 2010)
     @test Utils.find_season_and_year(dates[5]) == ("MAM", 2010)
@@ -118,7 +118,7 @@ end
     @test Utils.find_season_and_year(dates[9]) == ("SON", 2010)
     @test Utils.find_season_and_year(dates[10]) == ("SON", 2010)
     @test Utils.find_season_and_year(dates[11]) == ("SON", 2010)
-    @test Utils.find_season_and_year(dates[12]) == ("DJF", 2010)
+    @test Utils.find_season_and_year(dates[12]) == ("DJF", 2011)
 end
 
 @testset "split by season across time" begin

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -2388,6 +2388,13 @@ end
     @test seasonal_vars[4].attributes["season"] == "SON"
     @test seasonal_vars[6].attributes["season"] == "MAM"
 
+    # Check years
+    @test seasonal_vars[1].attributes["year"] == "2024"
+    @test seasonal_vars[2].attributes["year"] == "2024"
+    @test seasonal_vars[3].attributes["year"] == "2024"
+    @test seasonal_vars[4].attributes["year"] == "2024"
+    @test seasonal_vars[6].attributes["year"] == "2025"
+
     # Check arrays for time is correct
     @test seasonal_vars[1].dims["time"] == [0.0, 2_678_400.0]
     @test seasonal_vars[2].dims["time"] ==


### PR DESCRIPTION
This PR adds `Var.average_seasons_across_time`, which computes the seasonal average of an `OutputVar` and returns a single `OutputVar`. In addition, the attributes `year` and `season` are stored in the returned `OutputVar` as vectors of years and seasons, respectively.
