### PR TITLE
Fix reductions with one single point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,10 @@ unflattened_var = ClimaAnalysis.unflatten(flat_var)
 unflattened_var = ClimaAnalysis.unflatten(flat_var.metadata, flat_var.data)
 ```
 
+## Bug fixes
+
+- Fixed support for reductions when dimensions have only one point.
+
 v0.5.17
 -------
 

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -83,6 +83,14 @@ function _integrate_over_generic_dim(
     angle_idx,
     int_weights,
 )
+    # Support the `dims` keyword argument
+    if angle_idx isa Tuple || angle_idx isa Array
+        if length(angle_idx) == 1
+            angle_idx = only(angle_idx)
+        else
+            error("Only one `angle_idx` supported")
+        end
+    end
     # Reshape to add extra dimensions for int_weights for broadcasting if needed
     size_to_reshape =
         (i == angle_idx ? length(int_weights) : 1 for i in 1:ndims(data))


### PR DESCRIPTION
By default, reductions in Julia do not change the shape of the data. Some of our functions behave like reductions (and are used in `_reduce_over`) but change the shape (removing the dimension).

This leads to problems when the dimensions have only one point, as `_reduce_over` would remove them.

In this commit, I change our functions to behave like reductions.
