### PR TITLE
Add seasons keyword argument to split_by_season

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,17 @@ seasonal_averages_var.attributes["season"]
 seasonal_averages_var.attributes["year"]
 ```
 
+## New keyword argument for `split_by_season`
+
+You can now specify the order of the seasons for `split_by_season`. See the
+example below of specifying the order of the seasons being returned. This is
+helpful if you only want one season, or you want the seasons in a particular
+order.
+
+```julia
+DJF, SON = split_by_season(var, seasons = ("DJF", "SON"))
+```
+
 ## Bug fixes
 
 - Fixed support for reductions when dimensions have only one point.

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -219,6 +219,12 @@ isempty(SON) # empty OutputVar because no dates between September to November
 [MAM.data, JJA.data, DJF.data]
 ```
 
+!!! note "`seasons` keyword argument"
+    In ClimaAnalysis v0.5.19, the `seasons` keyword argument allows you to change the order
+    of the seasons or select only certain seasons. For example, you can call
+    `split_by_season(var, seasons = ("DJF", "SON"))` to extract only the seasons `DJF` and
+    `SON`, in that order.
+
 ### Split by season and year
 
 It may be the case that you want to split a `OutputVar` by season, while keeping each year

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -265,7 +265,8 @@ function warp_string(str::AbstractString; max_width = 70)
 end
 
 """
-    split_by_season(dates::AbstractArray{<: Dates.DateTime})
+    split_by_season(dates::AbstractArray{<: Dates.DateTime};
+                    seasons = ("MAM", "JJA", "SON", "DJF")))
 
 Return four vectors with `dates` split by seasons.
 
@@ -284,11 +285,20 @@ julia> split_by_season(dates)
 ([Dates.DateTime("2024-03-01T00:00:00")], [Dates.DateTime("2024-06-01T00:00:00")], [Dates.DateTime("2024-09-01T00:00:00")], [Dates.DateTime("2024-01-01T00:00:00")])
 ```
 """
-function split_by_season(dates::AbstractArray{<:Dates.DateTime})
+function split_by_season(
+    dates::AbstractArray{<:Dates.DateTime};
+    seasons = ("MAM", "JJA", "SON", "DJF"),
+)
+    all(season -> season in ("MAM", "JJA", "SON", "DJF"), seasons) ||
+        error("$seasons does not contain only seasons")
+
     MAM, JJA, SON, DJF = Vector{Dates.DateTime}(),
     Vector{Dates.DateTime}(),
     Vector{Dates.DateTime}(),
     Vector{Dates.DateTime}()
+
+    season_to_dates =
+        Dict("MAM" => MAM, "JJA" => JJA, "SON" => SON, "DJF" => DJF)
 
     for date in dates
         if Dates.Month(3) <= Dates.Month(date) <= Dates.Month(5)
@@ -302,7 +312,7 @@ function split_by_season(dates::AbstractArray{<:Dates.DateTime})
         end
     end
 
-    return (MAM, JJA, SON, DJF)
+    return tuple((season_to_dates[season] for season in seasons)...)
 end
 
 """

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1942,7 +1942,7 @@ end
 
 
 """
-    split_by_season(var::OutputVar)
+    split_by_season(var::OutputVar; seasons = ("MAM", "JJA", "SON", "DJF"))
 
 Return a vector of four `OutputVar`s split by season.
 
@@ -1964,16 +1964,18 @@ expected to be second.
 This function differs from `split_by_season_across_time` as `split_by_season_across_time`
 splits dates by season for each year.
 """
-function split_by_season(var::OutputVar)
-    _check_time_dim(var::OutputVar)
+function split_by_season(var::OutputVar; seasons = ("MAM", "JJA", "SON", "DJF"))
+    _check_time_dim(var)
     start_date = Dates.DateTime(var.attributes["start_date"])
 
-    season_dates = split_by_season(time_to_date.(start_date, times(var)))
+    season_dates = split_by_season(
+        time_to_date.(start_date, times(var)),
+        seasons = seasons,
+    )
     season_times =
         (date_to_time.(start_date, season) for season in season_dates)
 
     season_vars = _split_along_dim(var, time_name(var), season_times)
-    seasons = ["MAM", "JJA", "SON", "DJF"]
     for (season, season_var) in zip(seasons, season_vars)
         isempty(season_var) || (season_var.attributes["season"] = season)
     end

--- a/test/test_Utils.jl
+++ b/test/test_Utils.jl
@@ -103,6 +103,18 @@ end
     )
 
     @test Utils.split_by_season(dates) == expected_dates
+
+    # Different order for seasons
+    @test Utils.split_by_season(dates; seasons = ("MAM",)) ==
+          (expected_dates[1],)
+    @test Utils.split_by_season(dates; seasons = ("MAM", "DJF", "MAM")) ==
+          (expected_dates[1], expected_dates[4], expected_dates[1])
+
+    # Error handling
+    @test_throws ErrorException Utils.split_by_season(
+        dates,
+        seasons = ("not a season",),
+    )
 end
 
 @testset "find season and year" begin

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -2328,6 +2328,25 @@ end
     # Check empty OutputVar
     @test isempty(SON)
 
+    # Split by season with seasons kwarg
+    DJF, JJA = ClimaAnalysis.split_by_season(var, seasons = ("DJF", "JJA"))
+
+    # Check season is available as an attributes
+    @test JJA.attributes["season"] == "JJA"
+    @test DJF.attributes["season"] == "DJF"
+
+    # Check size of data
+    @test size(JJA.data) == (length(lat), 3, length(lon))
+    @test size(DJF.data) == (length(lat), 1, length(lon))
+
+    # Check times are correct in OutputVars
+    @test JJA.dims["time"] == [13_132_800.0, 13_132_802.0, 13_132_803.0]
+    @test DJF.dims["time"] == [0.0]
+
+    # Check start date
+    JJA.attributes["start_date"] == "2024-1-1"
+    DJF.attributes["start_date"] == "2024-1-1"
+
     # Check error handling
     attribs_no_start_date = Dict("long_name" => "hi")
     var =


### PR DESCRIPTION
closes #278 - This PR adds the `seasons` keyword argument to `split_by_season`. This is helpful if you need only some of the seasons or want to change the order of the seasons that is being returned.
