### PR TITLE
Add more function signature for replace 

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -91,7 +91,9 @@ Var.apply_landmask
 Var.apply_oceanmask
 Var.make_lonlat_mask
 Base.replace(var::OutputVar, old_new::Pair...; count::Integer)
+Base.replace(new::Union{Function, Type}, var::OutputVar; count::Integer)
 Base.replace!(var::OutputVar, old_new::Pair...; count::Integer)
+Base.replace!(new::Union{Function, Type}, var::OutputVar; count::Integer)
 Base.cat(vars::OutputVar...; dim::String)
 Var.reverse_dim
 Var.reverse_dim!

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -90,8 +90,8 @@ Var.shift_to_start_of_previous_month
 Var.apply_landmask
 Var.apply_oceanmask
 Var.make_lonlat_mask
-Base.replace(var::OutputVar, old_new::Pair...)
-Base.replace!(var::OutputVar, old_new::Pair...)
+Base.replace(var::OutputVar, old_new::Pair...; count::Integer)
+Base.replace!(var::OutputVar, old_new::Pair...; count::Integer)
 Base.cat(vars::OutputVar...; dim::String)
 Var.reverse_dim
 Var.reverse_dim!

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2673,6 +2673,34 @@ function Base.replace!(
     replace!(var.data, old_new..., count = count)
     return nothing
 end
+
+"""
+    replace!(new::Union{Function, Type}, var::OutputVar; [count::Integer])
+
+Return a new `OutputVar where each value of `var.data` is replaced by `new(x)`. If `count`
+is specified, then replace at most `count` values in total.
+"""
+function Base.replace(
+    new::Union{Function, Type},
+    var::OutputVar;
+    count::Integer = typemax(Int),
+)
+    replaced_data = replace(new, var.data, count = count)
+    return remake(var, data = replaced_data)
+end
+
+"""
+    replace!(new::Union{Function, Type}, var::OutputVar; [count::Integer])
+
+Return each value of `var.data` by `new(x)`. If `count` is specified, then replace at most
+`count` values in total.
+"""
+function Base.replace!(
+    new::Union{Function, Type},
+    var::OutputVar;
+    count::Integer = typemax(Int),
+)
+    replace!(new, var.data, count = count)
     return nothing
 end
 

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2646,13 +2646,17 @@ This function is useful if there are `NaN`s or `missing` values in the data. For
 you want to use the ocean mask, but there are `NaN`s in the ocean. You can replace all the
 `NaN` and `missing` values with 0.0 and apply the ocean mask afterward.
 """
-function Base.replace(var::OutputVar, old_new::Pair...)
-    replaced_data = replace(var.data, old_new...)
+function Base.replace(
+    var::OutputVar,
+    old_new::Pair...;
+    count::Integer = typemax(Int),
+)
+    replaced_data = replace(var.data, old_new..., count = count)
     return remake(var, data = replaced_data)
 end
 
 """
-    replace!(var::OutputVar, old_new::Pair...)
+    replace!(var::OutputVar, old_new::Pair...; [count::Integer])
 
 For each pair `old  => new`, all occurences of `old` are replaced by `new` in
 `var.data`. See [`replace`](@ref).
@@ -2661,8 +2665,14 @@ This function is useful if there are `NaN`s or `missing` values in the data. For
 you want to use the ocean mask, but there are `NaN`s in the ocean. You can replace all the
 `NaN` and `missing` values with 0.0 and apply the ocean mask afterward.
 """
-function Base.replace!(var::OutputVar, old_new::Pair...)
-    replace!(var.data, old_new...)
+function Base.replace!(
+    var::OutputVar,
+    old_new::Pair...;
+    count::Integer = typemax(Int),
+)
+    replace!(var.data, old_new..., count = count)
+    return nothing
+end
     return nothing
 end
 

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -3027,6 +3027,31 @@ end
     @test var.data == [100.0, 2.0, -1.0]
 end
 
+@testset "Replace with function" begin
+    times = [1.0, 2.0, 3.0]
+    data = [NaN, 2.0, NaN]
+    var =
+        TemplateVar() |>
+        add_dim("time", times, units = "s") |>
+        add_attribs(long_name = "hi") |>
+        add_data(data = data) |>
+        initialize
+
+    replaced_var = replace(x -> isnan(x) ? 2.0 : x, var)
+    @test replaced_var.data == [2.0, 2.0, 2.0]
+
+    replaced_var = replace(x -> isnan(x) ? 2.0 : x, var, count = 1)
+    @test isequal(replaced_var.data, [2.0, 2.0, NaN])
+
+    var1 = ClimaAnalysis.remake(var)
+    var2 = ClimaAnalysis.remake(var)
+
+    replace!(x -> isnan(x) ? 2.0 : x, var1)
+    @test var1.data == [2.0, 2.0, 2.0]
+    replace!(x -> isnan(x) ? 2.0 : x, var2, count = 1)
+    @test isequal(var2.data, [2.0, 2.0, NaN])
+end
+
 @testset "Concatenate OutputVars" begin
     # Initialize 3D OutputVar (lon, lat, time)
     times = Float64[

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -3009,6 +3009,22 @@ end
     # Test in place replace
     replace!(var, missing => 1.0, NaN => 2.0)
     @test var.data == [[1.0, 2.0] [2.0, 1.0]]
+
+    # Test with count keyword argument
+    times = [1.0, 2.0, 3.0]
+    data = [-1.0, 2.0, -1.0]
+    var =
+        TemplateVar() |>
+        add_dim("time", times, units = "s") |>
+        add_attribs(long_name = "hi") |>
+        add_data(data = data) |>
+        initialize
+
+    replaced_var = replace(var, -1.0 => 100.0, count = 1)
+    @test replaced_var.data == [100.0, 2.0, -1.0]
+
+    replace!(var, -1.0 => 100.0, count = 1)
+    @test var.data == [100.0, 2.0, -1.0]
 end
 
 @testset "Concatenate OutputVars" begin


### PR DESCRIPTION
This PR adds `replace(new, var)` and `replace!(new, var)`, where `new` is a function or type, and `var` is a `OutputVar`. Additionally, the count keyword argument is added to all `replace` functions.