### PR TITLE
Fix masking and permutedims

### DIFF
--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1440,7 +1440,9 @@ function Base.permutedims(var::OutputVar, perm)
 
     # Find permutation indices to reorder dims
     reorder_indices =
-        indexin(conventional_dim_name_perm, conventional_dim_name_var)
+        something.(
+            indexin(conventional_dim_name_perm, conventional_dim_name_var)
+        )
 
     # Reorder dims, dim_attribs, and data, but not attribs
     ret_dims = deepcopy(var.dims)

--- a/src/masks.jl
+++ b/src/masks.jl
@@ -68,6 +68,8 @@ function generate_lonlat_mask(
     length(mask_var.dims) == 2 ||
         error("Number of dimensions ($(length(mask_var.dims))) is not two")
 
+    mask_var = permutedims(mask_var, ("lon", "lat"))
+
     function apply_lonlat_mask(var)
         # Check if longitude and latitude exist in var
         has_longitude(var) || error("var does not has a longitude dimension")

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -3509,6 +3509,9 @@ end
 
     mask = ClimaAnalysis.generate_lonlat_mask(mask_var, NaN, 100.0)
 
+    permuted_var = permutedims(mask_var, ("latitude", "longitude"))
+    permuted_mask = ClimaAnalysis.generate_lonlat_mask(permuted_var, NaN, 100.0)
+
     var =
         TemplateVar() |>
         add_dim("longitude", lon, units = "degrees") |>
@@ -3526,6 +3529,18 @@ end
             [[NaN, 100.0] [100.0, NaN] [NaN, 100.0]],
         )
     end
+
+    # Permuting the mask should not change the mask
+    permuted_masked_var = permuted_mask(var)
+    @test isequal(masked_var.data, permuted_masked_var.data)
+
+    # Permute the OutputVar should not change the mask
+    permuted_var = permutedims(var, ("time", "longitude", "latitude"))
+    masked_permuted_var = mask(permuted_var)
+    masked_permuted_var =
+        permutedims(masked_permuted_var, ("longitude", "time", "latitude"))
+    @test isequal(masked_var.data, masked_permuted_var.data)
+
 
     # Error handling
     # Binary mask


### PR DESCRIPTION
This PR fixes an issue with masking and `permutedims`.

The issue with masking is that if the mask is generated from a `OutputVar` with dimensions latitude and longitude in that order, then the mask will be wrong. This is because the rest of the code assumes the order of dimensions is longitude and latitude.

The issue with `permutedims` is that newer versions of Julia requires that the array of the element type of `perm` to not include `nothing`. 