### PR TITLE
Add NCCatalog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,20 @@ pr_var = ClimaAnalysis.OutputVar(["pr1.nc", "pr2.nc"])
 to load the NetCDF files "pr1.nc" and "pr2.nc" along the time dimension in a
 `OutputVar`.
 
+## NCCatalog
+
+You can now organize and easily load external NetCDF files with `ClimaAnalysis.NCCatalog`.
+See the example below of adding a file and loading a variable from the file as a
+`OutputVar`.
+
+```julia
+catalog = ClimaAnalysis.NCCatalog()
+# The file "precip.nc" contains a variable named "precip", but you can retrieve it as "pr".
+ClimaAnalysis.add_file!(catalog, "precip.nc", "precip" => "pr")
+# The short name of pr_var is "pr".
+pr_var = get(catalog, "pr")
+```
+
 v0.5.18
 -------
 This release introduces the following features and bug fixes

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,6 +31,7 @@ makedocs(;
         "Home" => "index.md",
         "OutputVars" => "var.md",
         "Visualizing OutputVars" => "visualize.md",
+        "Reading NetCDF files" => "read_files.md",
         "RMSEVariables" => "rmse_var.md",
         "Visualizing RMSEVariables" => "visualize_rmse_var.md",
         "FlatVar" => "flat.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,11 +8,22 @@ CurrentModule = ClimaAnalysis
 
 ```@docs
 Sim.SimDir
-Base.get
-Sim.available_vars
+get(simdir::SimDir)
+get(simdir::SimDir, short_names...)
+available_vars(simdir::SimDir)
 Sim.available_reductions
 Sim.available_periods
 Base.show(io::IO, simdir::SimDir)
+```
+
+## Catalog
+
+```@docs
+Catalog.NCCatalog
+Catalog.NCCatalog()
+Catalog.add_file!
+get(catalog::NCCatalog, short_name; var_kwargs = ())
+Catalog.available_vars(catalog::NCCatalog)
 ```
 
 ## Var

--- a/docs/src/read_files.md
+++ b/docs/src/read_files.md
@@ -1,0 +1,46 @@
+# Organizing and loading NetCDF files
+
+`ClimaAnalysis` provides `SimDir` and `NCCatalog` for organizing and loading `OutputVar`s
+from NetCDF files. For output from a `CliMA` simulation, use `SimDir`, and for external
+NetCDF files, use `NCCatalog`.
+
+## `SimDir`
+
+For information about `SimDir`, see the [`SimDir`](index.md#SimDir) section in the
+quickstart guide.
+
+## `NCCatalog`
+
+For NetCDF files not generated from a `CliMA` simulation, you can use
+[`ClimaAnalysis.NCCatalog`](@ref) to organize and retrieve variables from the NetCDF files.
+
+The first step is to instantiate a [`ClimaAnalysis.NCCatalog()`](@ref).
+
+```julia
+import ClimaAnalysis
+
+catalog = ClimaAnalysis.NCCatalog()
+```
+
+To populate the catalog, you can use [`ClimaAnalysis.add_file!`](@ref).
+
+You don't need to provide short names to `add_file!`, but if multiple files contain the same
+variable name, `ClimaAnalysis` will load from the file that was added first. To ensure that
+the variable is loaded from a specific file, provide the short name (e.g., `"rsdt"`) or an
+alias (e.g., `"precip" => "pr"`). If an alias is provided, then the short name of the
+`OutputVar` will be renamed accordingly.
+
+```julia
+ClimaAnalysis.add_file!(catalog, "gpp.nc")
+ClimaAnalysis.add_file!(catalog, "precip.nc", "precip" => "pr")
+ClimaAnalysis.add_file!(catalog, "radiation.nc", "rsdt", "rsut", "toa_lw_all_mon" => "rlut")
+```
+
+Finally, to retrieve a variable from the `NCCatalog`, you can call `get`. Additional keyword
+arguments for constructing the [`ClimaAnalysis.OutputVar`](@ref) can be passed as
+`var_kwargs`.
+
+```julia
+pr_var = get(catalog, "pr")
+rlut_var = get(catalog, "rsut", var_kwargs = (shift_by = Dates.firstdayofmonth,))
+```

--- a/src/Catalog.jl
+++ b/src/Catalog.jl
@@ -1,0 +1,140 @@
+module Catalog
+
+import NCDatasets
+
+import Base: get
+import ..Sim: available_vars
+import ..Var: OutputVar
+
+export NCCatalog, add_file!, available_vars
+
+"""
+    Organize external NetCDF files to easily initialize `OutputVar`s.
+"""
+struct NCCatalog
+    "Dictionary that maps aliases to tuples of file path and variable name in the NetCDF
+    file. The identifier can either be the variable name or an alias for the variable name
+    in the file."
+    identifier_to_path_varname::Dict{String, Tuple{String, String}}
+
+    "Dictionary that maps variable names to filepaths. This is a fallback if a variable is
+    requested and cannot be found in `identifier_to_path_varname`."
+    varname_to_filepath::Dict{String, String}
+end
+
+"""
+    NCCatalog()
+
+Construct an empty `NCCatalog`.
+
+Files can be added with [`ClimaAnalysis.Catalog.add_file!`](@ref).
+"""
+function NCCatalog()
+    identifier_to_path_varname = Dict{String, Tuple{String, String}}()
+    varname_to_filepath = Dict{String, String}()
+    return NCCatalog(identifier_to_path_varname, varname_to_filepath)
+end
+
+"""
+    add_file!(catalog::NCCatalog, filepath, short_names...)
+
+Add the file at `filepath` to `catalog` with `short_names`.
+
+The argument `short_names` can either be a short name (e.g., `"rsdt"`) or a pair of strings
+(e.g., `"solar_mon" => "rsdt"`). If a pair is used, then the first name is the variable name
+in the NetCDF file and the second name is the alias which will be used for `get`.
+
+!!! note "Multiple files with the same short names"
+    If there are multiple files that contain the same short names, then you should pass in
+    the desired file first or pass in a short name or a pair of short name to alias for
+    `short_names` to make the variable in the file retrievable with `get`.
+"""
+function add_file!(catalog::NCCatalog, filepath, short_names...)
+    isfile(filepath) || throw(ArgumentError("$filepath is not a file"))
+    endswith(filepath, ".nc") || throw(
+        ArgumentError(
+            "$filepath is not a NetCDF file, because the file path does not end with .nc",
+        ),
+    )
+
+    maybe_short_name_pairs = short_names
+    NCDatasets.NCDataset(filepath) do nc
+        unordered_dims = NCDatasets.dimnames(nc)
+        varnames = setdiff(keys(nc), unordered_dims)
+
+        foreach(
+            varname -> get!(catalog.varname_to_filepath, varname, filepath),
+            varnames,
+        )
+
+        for maybe_short_name_pair in maybe_short_name_pairs
+            maybe_short_name_pair isa Pair || (
+                maybe_short_name_pair =
+                    maybe_short_name_pair => maybe_short_name_pair
+            )
+            var_name = maybe_short_name_pair[1]
+            identifier = maybe_short_name_pair[2]
+            if !(var_name in varnames)
+                @warn "Cannot find $var_name in file. Variable will not be added"
+            elseif identifier in keys(catalog.identifier_to_path_varname)
+                @warn "Identifier $identifier is already in catalog. Variable will not be added"
+            else
+                catalog.identifier_to_path_varname[identifier] =
+                    (filepath, var_name)
+            end
+        end
+    end
+    return nothing
+end
+
+"""
+    get(catalog::NCCatalog, short_name; var_kwargs)
+
+Return a `OutputVar` with `short_name` from `catalog`.
+
+The keyword argument `var_kwargs` is a tuple of keyword arguments passed to `OutputVar`. See
+[`ClimaAnalysis.Var.OutputVar`](@ref) for a list of keyword arguments that can be passed.
+
+Any short names or aliases specified when adding files are searched first to identify which
+variable to load. If `short_name` cannot be found, then files are searched in the order that
+the files are added to identify which variable to load.
+"""
+function get(catalog::NCCatalog, short_name; var_kwargs = ())
+    filepath_varname_tuple =
+        get(catalog.identifier_to_path_varname, short_name, nothing)
+    if isnothing(filepath_varname_tuple)
+        filepath = get(catalog.varname_to_filepath, short_name, nothing)
+        isnothing(filepath) &&
+            error("Cannot find variable with $short_name in catalog")
+        varname = short_name
+    else
+        filepath, varname = filepath_varname_tuple
+    end
+    var = OutputVar(filepath, varname; var_kwargs...)
+    var.attributes["short_name"] = short_name
+    return var
+end
+
+"""
+    available_vars(catalog::NCCatalog)
+
+Return the short names of the variables found in `catalog`.
+
+Both aliases and variable names in the NetCDF files are returned.
+"""
+function available_vars(catalog::NCCatalog)
+    varnames_from_files = keys(catalog.varname_to_filepath)
+    identifiers = keys(catalog.identifier_to_path_varname)
+    return union(identifiers, varnames_from_files)
+end
+
+"""
+    Base.isempty(catalog::NCCatalog)
+
+Check if `NCCatalog` contains any files.
+"""
+function Base.isempty(catalog::NCCatalog)
+    return isempty(catalog.varname_to_filepath)
+end
+
+end

--- a/src/ClimaAnalysis.jl
+++ b/src/ClimaAnalysis.jl
@@ -10,6 +10,8 @@ include("Var.jl")
 @reexport using .Var
 include("Sim.jl")
 @reexport using .Sim
+include("Catalog.jl")
+@reexport using .Catalog
 include("Leaderboard.jl")
 @reexport using .Leaderboard
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ using Test
 @safetestset "Utils" begin @time include("test_Utils.jl") end
 @safetestset "Numerics" begin @time include("test_Numerics.jl") end
 @safetestset "SimDir" begin @time include("test_Sim.jl") end
+@safetestset "Catalog" begin @time include("test_Catalog.jl") end
 @safetestset "Atmos" begin @time include("test_Atmos.jl") end
 @safetestset "Leaderboard" begin @time include("test_Leaderboard.jl") end
 @safetestset "Template" begin @time include("test_Template.jl") end

--- a/test/test_Catalog.jl
+++ b/test/test_Catalog.jl
@@ -1,0 +1,78 @@
+using Test
+import ClimaAnalysis
+import Dates
+
+@testset "NCCatalog" begin
+    catalog = ClimaAnalysis.NCCatalog()
+    @test isempty(catalog)
+
+    gpp_path = joinpath(@__DIR__, "sample_nc/test_gpp.nc")
+    ClimaAnalysis.add_file!(catalog, gpp_path, "gpp" => "cool_gpp")
+    @test !isempty(catalog)
+    var_names = ["cool_gpp", "gpp"]
+    available_vars_in_catalog = ClimaAnalysis.available_vars(catalog)
+    for var_name in var_names
+        @test var_name in available_vars_in_catalog
+    end
+
+    pr_path = joinpath(@__DIR__, "sample_nc/test_pr.nc")
+    ClimaAnalysis.add_file!(catalog, pr_path, "precip" => "pr")
+    @test !isempty(catalog)
+    var_names = ["pr", "precip", "cool_gpp", "gpp"]
+    available_vars_in_catalog = ClimaAnalysis.available_vars(catalog)
+    for var_name in var_names
+        @test var_name in available_vars_in_catalog
+    end
+
+    pr_path2 = joinpath(@__DIR__, "sample_nc/test_pr2.nc")
+    ClimaAnalysis.add_file!(catalog, pr_path2)
+    @test !isempty(catalog)
+    var_names = ["pr", "precip", "cool_gpp", "gpp"]
+    available_vars_in_catalog = ClimaAnalysis.available_vars(catalog)
+    for var_name in var_names
+        @test var_name in available_vars_in_catalog
+    end
+
+    # Test errors
+    not_nc_path = joinpath(@__DIR__, "test_Catalog.jl")
+    @test_throws ArgumentError ClimaAnalysis.add_file!(catalog, not_nc_path)
+    @test_throws ArgumentError ClimaAnalysis.add_file!(catalog, @__DIR__)
+
+    # Test warnings
+    @test_logs (:warn, r"Cannot find") ClimaAnalysis.add_file!(
+        catalog,
+        gpp_path,
+        "rad_gpp",
+    )
+    @test_logs (:warn, r"Cannot find") ClimaAnalysis.add_file!(
+        catalog,
+        gpp_path,
+        "rad_gpp" => "more_rad_gpp",
+    )
+    @test_logs (:warn, r"is already in catalog") ClimaAnalysis.add_file!(
+        catalog,
+        gpp_path,
+        "gpp" => "cool_gpp",
+    )
+
+    gpp = get(catalog, "gpp")
+    @test gpp.attributes["short_name"] == "gpp"
+
+    # Both OutputVars should be the same since pr_path was added before pr_path2
+    precip = get(catalog, "precip")
+    pr = get(catalog, "pr")
+    @test precip.data == pr.data
+    @test precip.dims == precip.dims
+    @test all(
+        precip.attributes[key] == pr.attributes[key] for
+        key in union(keys(precip.attributes), keys(pr.attributes)) if
+        key != "short_name"
+    )
+    @test precip.dim_attributes == pr.dim_attributes
+    @test precip.attributes["short_name"] == "precip"
+
+    # Test keyword arguments work
+    pr = get(catalog, "pr", var_kwargs = (shift_by = Dates.lastdayofmonth,))
+    @test ClimaAnalysis.dates(pr) ==
+          [Dates.DateTime(1979, 1, 31), Dates.DateTime(2023, 5, 31)]
+end


### PR DESCRIPTION
This PR adds `NCCatalog` for organizing and loading `OutputVar` from NetCDF files. This is the first step towards cleaning up the how data is loaded from NetCDF files and for processing them as the interface between `SimDir` and `NCCatalog` should mostly be the same.


TODO
- [x] Add to NEWS.md