### PR TITLE
Add LonLatMask

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -91,6 +91,8 @@ Var.LonLatMask
 Var.apply_landmask
 Var.apply_oceanmask
 Var.generate_lonlat_mask
+Var.generate_land_mask
+Var.generate_ocean_mask
 Var.make_lonlat_mask
 Base.replace(var::OutputVar, old_new::Pair...; count::Integer)
 Base.replace(new::Union{Function, Type}, var::OutputVar; count::Integer)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -87,6 +87,7 @@ Var.squared_error
 Var.global_mse
 Var.global_rmse
 Var.shift_to_start_of_previous_month
+Var.LonLatMask
 Var.apply_landmask
 Var.apply_oceanmask
 Var.generate_lonlat_mask

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -402,7 +402,7 @@ equal to `threshold` are rounded to one and all other values are rounded to zero
 var = replace(x -> isnan(x) ? 0.0 : 1.0, var)
 
 # Any points that are NaNs should be zero in the mask
-mask_fn = ClimaAnalysis.generate_lonlat_mask(
+lonlat_mask = ClimaAnalysis.generate_lonlat_mask(
     var,
     NaN, # zero to NaN
     1.0; # one to one
@@ -410,9 +410,9 @@ mask_fn = ClimaAnalysis.generate_lonlat_mask(
 )
 
 # Apply mask to another OutputVar
-another_masked_var = mask_fn(another_var)
+another_masked_var = lonlat_mask(another_var)
 
 # Compute squared error and global MSE with custom masking function
-ClimaAnalysis.squared_error(sim_var, obs_var, mask = mask_fn)
-ClimaAnalysis.global_mse(sim_var, obs_var, mask = mask_fn)
+ClimaAnalysis.squared_error(sim_var, obs_var, mask = lonlat_mask)
+ClimaAnalysis.global_mse(sim_var, obs_var, mask = lonlat_mask)
 ```


### PR DESCRIPTION
This PR adds the struct `LonLatMask`. This is the first of the two PRs for implementing mask-aware flatten.

The reason for this struct is that when flattening, you need to access the bit mask rather than the masked `OutputVar`.