### PR TITLE
Add shift_by functions for a month and week

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,17 @@ ClimaAnalysis.flattened_length(flat_var)
 ClimaAnalysis.flattened_length(flat_var.metadata)
 ```
 
+## Shift to previous day and week
+
+To support different diagnostics whose reductions span a day or week,
+ClimaAnalysis provides the `shift_to_previous_day` and `shift_to_previous_week`
+functions that shift the dates to the previous day or week respectively.
+
+```julia
+shifted_daily = ClimaAnalysis.shift_to_previous_day(var)
+shifted_weekly = ClimaAnalysis.shift_to_previous_week(var)
+```
+
 ## Bug fixes
 - Fixed conversion from dates to relative times for NetCDF files where the
   temporal dimension is typed as `Union{T, Missing}`, where `T` is a subtype of

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -100,6 +100,8 @@ Var.squared_error
 Var.global_mse
 Var.global_rmse
 Var.shift_to_start_of_previous_month
+Var.shift_to_previous_week
+Var.shift_to_previous_day
 Var.LonLatMask
 Var.apply_landmask
 Var.apply_oceanmask

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -394,3 +394,36 @@ the example below of this usage.
 var_reversed = reverse_dim(var, "pressure_level")
 reverse_dim!(var, "pressure_level") # in-place
 ```
+
+## How do I shift the dates in a `OutputVar`?
+
+You can shift dates using [`shift_to_start_of_previous_month`](@ref),
+[`shift_to_previous_week`](@ref), and [`shift_to_previous_day`](@ref).
+
+```@setup shift_by
+import Dates
+import ClimaAnalysis
+import ClimaAnalysis.Template:
+    TemplateVar,
+    add_attribs,
+    add_dim,
+    initialize
+time = ClimaAnalysis.Utils.date_to_time.(
+        Dates.DateTime(2010, 1),
+        [Dates.DateTime(2010, i) for i in 1:3])
+var =
+    TemplateVar() |>
+    add_dim("time", time, units = "s") |>
+    add_attribs(short_name = "pr", start_date = "2010-1-1") |>
+    initialize
+```
+
+```@repl shift_by
+ClimaAnalysis.dates(var)
+ClimaAnalysis.shift_to_start_of_previous_month(var) |> ClimaAnalysis.dates
+ClimaAnalysis.shift_to_previous_week(var) |> ClimaAnalysis.dates
+ClimaAnalysis.shift_to_previous_day(var) |> ClimaAnalysis.dates
+```
+
+These functions are helpful with aligning the dates of observational and
+simulational data.

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -140,7 +140,9 @@ This function is helpful in ensuring consistency in dates between simulation and
 observational data. One example of this is when adjusting monthly averaged data. For
 instance, suppose that data on 2010-02-01 in `sim_var` corresponds to the monthly
 average for January. This function shifts the times so that 2010-01-01 will correspond to
-the monthly average for January.
+the monthly average for January. See also [`shift_to_previous_day`](@ref) and
+[`shift_to_previous_week`](@ref) for diagnostics whose time reductions span a
+day or week respectively.
 
 
 ## Integration

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -67,6 +67,8 @@ export OutputVar,
     set_units,
     set_dim_units!,
     shift_to_start_of_previous_month,
+    shift_to_previous_week,
+    shift_to_previous_day,
     replace,
     replace!,
     reverse_dim,
@@ -2336,10 +2338,47 @@ the monthly average for January.
 
 Note that this function only works for the time dimension and will not work for the date
 dimension.
+
+See also [`shift_to_previous_week`](@ref) and [`shift_to_previous_day`](@ref).
 """
 function shift_to_start_of_previous_month(var::OutputVar)
     return _shift_by(var, date -> Dates.firstdayofmonth(date) - Dates.Month(1))
 end
+
+"""
+    shift_to_previous_day(var::OutputVar)
+
+Shift the times in the time dimension to the previous day.
+
+After applying this function, the start date in the attributes correspond to the first
+element in the time array.
+
+Note that this function only works for the time dimension and will not work for the date
+dimension.
+
+See also [`shift_to_start_of_previous_month`](@ref) and [`shift_to_previous_week`](@ref).
+"""
+function shift_to_previous_day(var::OutputVar)
+    return _shift_by(var, date -> date - Dates.Day(1))
+end
+
+"""
+    shift_to_previous_week(var::OutputVar)
+
+Shift the times in the time dimension to the previous week.
+
+After applying this function, the start date in the attributes correspond to the first
+element in the time array.
+
+Note that this function only works for the time dimension and will not work for the date
+dimension.
+
+See also [`shift_to_start_of_previous_month`](@ref) and [`shift_to_previous_day`](@ref).
+"""
+function shift_to_previous_week(var::OutputVar)
+    return _shift_by(var, date -> date - Dates.Week(1))
+end
+
 """
     _shift_by(var::OutputVar, date_func)
 

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -3320,6 +3320,33 @@ end
     )
 end
 
+@testset "Shift by previous week and day" begin
+    # Most of the functionality of these functions are already tested
+    # when testing shift_to_start_of_previous_month, so these tests mainly focus
+    # on the computation of the dates
+    time_arr = [
+        Dates.DateTime("2010-02-01T00:00:00"),
+        Dates.DateTime("2010-03-01T00:02:00"),
+        Dates.DateTime("2010-04-01T00:03:00"),
+    ]
+    var =
+        TemplateVar() |> add_dim("time", time_arr, blah = "blah") |> initialize
+    var_s = ClimaAnalysis.Var._dates_to_seconds(var)
+
+    shift_by_week = ClimaAnalysis.shift_to_previous_week(var_s)
+    shift_by_day = ClimaAnalysis.shift_to_previous_day(var_s)
+
+    shifted_dates_by_week = time_arr .- Dates.Week(1)
+    shifted_dates_by_day = time_arr .- Dates.Day(1)
+
+    @test ClimaAnalysis.dates(shift_by_week) == shifted_dates_by_week
+    @test Dates.DateTime(shift_by_week.attributes["start_date"]) ==
+          first(shifted_dates_by_week)
+    @test ClimaAnalysis.dates(shift_by_day) == shifted_dates_by_day
+    @test Dates.DateTime(shift_by_day.attributes["start_date"]) ==
+          first(shifted_dates_by_day)
+end
+
 @testset "Land and ocean masks" begin
     # Order of dimensions should not matter
     lat = collect(range(-89.5, 89.5, 180))


### PR DESCRIPTION
closes #329 - This PR adds `Var.shift_to_previous_week` and `Var.shift_to_previous_day`.

TODO

- [x] Add to NEWS.md
- [x] Add tests
- [x] Add to howdoi section