### PR TITLE
Warn when obs data has NaNs in error computation

### DIFF
--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2077,6 +2077,8 @@ function bias(sim::OutputVar, obs::OutputVar; mask = nothing)
 
     # Resample obs on sim to ensure the size of data in sim and obs are the same and the
     # dims are the same
+    any(isnan, obs.data) &&
+        @warn "NaNs detected in observational data, resampling is not NaN aware. If you applied a mask, pass the mask via the mask keyword argument instead"
     obs_resampled = resampled_as(obs, sim)
 
     # Compute bias
@@ -2157,6 +2159,8 @@ function squared_error(sim::OutputVar, obs::OutputVar; mask = nothing)
     _check_sim_obs_units_consistent(sim, obs, 2)
 
     # Resample obs on sim to ensure the size of data in sim and obs are the same and the dims are the same
+    any(isnan, obs.data) &&
+        @warn "NaNs detected in observational data, resampling is not NaN aware. If you applied a mask, pass the mask via the mask keyword argument instead"
     obs_resampled = resampled_as(obs, sim)
 
     # Compute squared error

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -2315,6 +2315,21 @@ end
     @test bias_var.attributes["global_bias"] == 1.0
     @test global_bias == 1.0
     @test bias_var.data == ones(length(lon), length(lat)) * 1.0
+
+    # Test warning is thrown about NaNs
+    nan_data = [[0.0, 0.0] [NaN, 0.0]]
+    nan_var =
+        TemplateVar() |>
+        add_dim("lon", [0.0, 1.0], units = "degrees") |>
+        add_dim("lat", [0.0, 1.0], units = "degrees") |>
+        add_attribs(long_name = "idk", short_name = "short", units = "kg") |>
+        add_data(data = nan_data) |>
+        initialize
+
+    @test_logs (:warn, r"NaNs detected in observational data") ClimaAnalysis.bias(
+        nan_var,
+        nan_var,
+    )
 end
 
 @testset "Compute mse" begin
@@ -2385,6 +2400,21 @@ end
         ClimaAnalysis.squared_error(var_not_unitful, var_not_unitful)
     @test ClimaAnalysis.units(var_unitful) == "(kg^2/m)^2"
     @test ClimaAnalysis.units(var_not_unitful) == "(wacky/weird^2)^2"
+
+    # Test warning is thrown about NaNs
+    nan_data = [[0.0, 0.0] [NaN, 0.0]]
+    nan_var =
+        TemplateVar() |>
+        add_dim("lon", [0.0, 1.0], units = "degrees") |>
+        add_dim("lat", [0.0, 1.0], units = "degrees") |>
+        add_attribs(long_name = "idk", short_name = "short", units = "kg") |>
+        add_data(data = nan_data) |>
+        initialize
+
+    @test_logs (:warn, r"NaNs detected in observational data") ClimaAnalysis.squared_error(
+        nan_var,
+        nan_var,
+    )
 end
 
 @testset "Units and dims check for error functions" begin


### PR DESCRIPTION
closes #332 - This PR adds a warning when `NaN`s are in the observational data.