### PR TITLE
Add units for binary operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 ClimaAnalysis.jl Release Notes
 ===============================
+main
+-------
+
+## Units for binary operations
+
+With this release, all resulting `OutputVar` from binary operations with
+`OutputVar`s and real numbers keep their units when appropriate.
+
 v0.5.20
 -------
 This release introduces the following features and bug fixes

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -176,9 +176,12 @@ For binary operations (e.g., `+, -, *, /`), `ClimaAnalysis` will check if the
 operation is well defined (i.e., the two variables are defined on the physical
 space). Binary operations do remove some attribute information. If two
 `OutputVar`s share the same start date, then the start date will remain in the
-resulting `OutputVar`s after performing binary operations on them.
+resulting `OutputVar`s after performing binary operations on them. When
+appropriate, the resulting `OutputVar` will retain its units. For example,
+addition and subtraction preserve matching units, and multiplication and
+division combine them.
 
-Unary operations are supported to, for example `log(max(var, 1e-8))` returns a
+Unary operations are supported too, for example `log(max(var, 1e-8))` returns a
 new `OutputVar` with the functions applied to the data.
 
 #### `Visualize`

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -368,6 +368,7 @@ end
             "short_name" => "bob + bula",
             "long_name" => "hi + bob",
             "start_date" => "2008", # Only start_date is common and identical
+            "units" => "",
         )
         @test var1plusvar3.dims == var1.dims # Check dims preserved
 
@@ -381,6 +382,7 @@ end
             "short_name" => "bob * bula",
             "long_name" => "hi * bob",
             "start_date" => "2008",
+            "units" => "",
         )
 
         var_times_real = var1 * 2.5
@@ -400,6 +402,7 @@ end
             "short_name" => "bob / bula",
             "long_name" => "hi / bob",
             "start_date" => "2008",
+            "units" => "",
         )
 
         # Subtraction (-)
@@ -411,6 +414,7 @@ end
             "short_name" => "bob - bula",
             "long_name" => "hi - bob",
             "start_date" => "2008",
+            "units" => "",
         )
 
         # Maximum (max)
@@ -422,6 +426,7 @@ end
             "short_name" => "bob max bula",
             "long_name" => "hi max bob",
             "start_date" => "2008",
+            "units" => "",
         )
 
         var1max1000 = max(var1, 1000.0)
@@ -441,6 +446,7 @@ end
             "short_name" => "bob min bula",
             "long_name" => "hi min bob",
             "start_date" => "2008",
+            "units" => "",
         )
 
         var1min1000 = min(var1, 1000.0)
@@ -508,6 +514,36 @@ end
             "start_date" => "2008",
         )
         @test neg_var1.dims == var1.dims
+    end
+end
+
+@testset "Units of binary operations" begin
+    time = [0.0]
+    template = TemplateVar() |> add_dim("time", time, units = "s")
+    units_var1 = template |> add_attribs(units = "kg") |> initialize
+    units_var2 = template |> add_attribs(units = "kg^2") |> initialize
+    no_units_var = template |> add_attribs(units = "") |> initialize
+
+    for f in [+, -, max, min]
+        @test ClimaAnalysis.units(f(units_var1, units_var1)) ==
+              ClimaAnalysis.units(units_var1)
+        @test ClimaAnalysis.units(f(units_var1, units_var2)) == ""
+        @test ClimaAnalysis.units(f(units_var1, no_units_var)) == ""
+
+        @test ClimaAnalysis.units(f(units_var1, 10.0)) ==
+              ClimaAnalysis.units(units_var1)
+        @test ClimaAnalysis.units(f(10.0, units_var1)) ==
+              ClimaAnalysis.units(units_var1)
+    end
+
+    for f in [*, /]
+        @test ClimaAnalysis.units(f(units_var1, units_var1)) == "(kg) $f (kg)"
+        @test ClimaAnalysis.units(f(units_var1, units_var2)) == "(kg) $f (kg^2)"
+        @test ClimaAnalysis.units(f(units_var1, no_units_var)) == ""
+        @test ClimaAnalysis.units(f(units_var1, 10.0)) ==
+              ClimaAnalysis.units(units_var1)
+        @test ClimaAnalysis.units(f(10.0, units_var1)) ==
+              ClimaAnalysis.units(units_var1)
     end
 end
 


### PR DESCRIPTION
closes #270 - This PR makes all binary operations adds units to the attributes when doing a binary operation. Because of the lack of a good units system, the resulting units is not simplified.