### PR TITLE
Use time_name in _shift_by

### DIFF
--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2420,7 +2420,7 @@ function _shift_by(var::OutputVar, date_func)
     ret_attribs = deepcopy(var.attributes)
     ret_attribs["start_date"] = string(start_date)
     ret_dims = deepcopy(var.dims)
-    ret_dims["time"] = time_arr
+    ret_dims[time_name(var)] = time_arr
     return remake(var, attributes = ret_attribs, dims = ret_dims)
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR fixes an assumption in `_shift_by(var,...)` that `time_name(var) == "time"`, indexing with `time_name` instead of "time".

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
