### PR TITLE
Add Var.transform_dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,19 @@ main
 With this release, all resulting `OutputVar` from binary operations with
 `OutputVar`s and real numbers keep their units when appropriate.
 
+## Transform dates
+
+This release introduces `transform_dates` which allow the user to pass a generic
+function that operates on the dates of a `OutputVar`. This is helpful to
+standardize the convention used for time for different datasets.
+
+```julia
+import Dates
+# var is a OutputVar
+# Transform the times of var by shifting the dates 6 hours back
+transform_dates(var, date -> date - Dates.Hour(6))
+```
+
 v0.5.20
 -------
 This release introduces the following features and bug fixes

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -103,6 +103,7 @@ Var.global_rmse
 Var.shift_to_start_of_previous_month
 Var.shift_to_previous_week
 Var.shift_to_previous_day
+Var.transform_dates
 Var.LonLatMask
 Var.apply_landmask
 Var.apply_oceanmask

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -395,10 +395,11 @@ var_reversed = reverse_dim(var, "pressure_level")
 reverse_dim!(var, "pressure_level") # in-place
 ```
 
-## How do I shift the dates in a `OutputVar`?
+## How do I shift or transform the dates in a `OutputVar`?
 
 You can shift dates using [`shift_to_start_of_previous_month`](@ref),
-[`shift_to_previous_week`](@ref), and [`shift_to_previous_day`](@ref).
+[`shift_to_previous_week`](@ref), [`shift_to_previous_day`](@ref), and
+[`transform_dates`](@ref).
 
 ```@setup shift_by
 import Dates
@@ -423,6 +424,7 @@ ClimaAnalysis.dates(var)
 ClimaAnalysis.shift_to_start_of_previous_month(var) |> ClimaAnalysis.dates
 ClimaAnalysis.shift_to_previous_week(var) |> ClimaAnalysis.dates
 ClimaAnalysis.shift_to_previous_day(var) |> ClimaAnalysis.dates
+ClimaAnalysis.transform_dates(var, date -> date - Dates.Hour(6)) |> ClimaAnalysis.dates
 ```
 
 These functions are helpful with aligning the dates of observational and

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -70,6 +70,7 @@ export OutputVar,
     shift_to_start_of_previous_month,
     shift_to_previous_week,
     shift_to_previous_day,
+    transform_dates,
     replace,
     replace!,
     reverse_dim,
@@ -2357,7 +2358,10 @@ dimension.
 See also [`shift_to_previous_week`](@ref) and [`shift_to_previous_day`](@ref).
 """
 function shift_to_start_of_previous_month(var::OutputVar)
-    return _shift_by(var, date -> Dates.firstdayofmonth(date) - Dates.Month(1))
+    return transform_dates(
+        var,
+        date -> Dates.firstdayofmonth(date) - Dates.Month(1),
+    )
 end
 
 """
@@ -2374,7 +2378,7 @@ dimension.
 See also [`shift_to_start_of_previous_month`](@ref) and [`shift_to_previous_week`](@ref).
 """
 function shift_to_previous_day(var::OutputVar)
-    return _shift_by(var, date -> date - Dates.Day(1))
+    return transform_dates(var, date -> date - Dates.Day(1))
 end
 
 """
@@ -2391,15 +2395,15 @@ dimension.
 See also [`shift_to_start_of_previous_month`](@ref) and [`shift_to_previous_day`](@ref).
 """
 function shift_to_previous_week(var::OutputVar)
-    return _shift_by(var, date -> date - Dates.Week(1))
+    return transform_dates(var, date -> date - Dates.Week(1))
 end
 
 """
-    _shift_by(var::OutputVar, date_func)
+    transform_dates(var::OutputVar, date_func)
 
 Apply `date_func` element-wise to the dates in `var`.
 """
-function _shift_by(var::OutputVar, date_func)
+function transform_dates(var::OutputVar, date_func)
     # Check if time dimension exists, floats are in the array, and unit of data is
     # second
     has_time(var) || error("Time is not a dimension of var")


### PR DESCRIPTION
closes #351 - This function adds `Var.transform_times` which allows the user to pass a generic function that transform the dates of the `OutputVar`.

