### PR TITLE
Fix bug with long name for slice with time values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,10 @@ import Dates
 transform_dates(var, date -> date - Dates.Hour(6))
 ```
 
+## Bug fixes
+- Fix bug with missing time value for long name after applying `slice` on a
+  `OutputVar` for non-positive time values
+
 v0.5.20
 -------
 This release introduces the following features and bug fixes

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -191,9 +191,20 @@ julia> seconds_to_prettystr(864010)
 
 julia> seconds_to_prettystr(24 * 60 * 60 * 365 + 1)
 "1y 1s"
+
+julia> seconds_to_prettystr(0)
+"0.0s"
+
+julia> seconds_to_prettystr(-864010)
+"-10d 10s"
 ```
 """
 function seconds_to_prettystr(seconds::Real)
+    iszero(seconds) && return "0.0s"
+
+    sign_prefix = signbit(seconds) ? "-" : ""
+    seconds = abs(seconds)
+
     time = String[]
 
     years, rem_seconds = divrem(seconds, 24 * 60 * 60 * 365)
@@ -211,7 +222,7 @@ function seconds_to_prettystr(seconds::Real)
     minutes > 0 && push!(time, "$(minutes)m")
     seconds > 0 && push!(time, "$(seconds)s")
 
-    return join(time, " ")
+    return sign_prefix * join(time, " ")
 end
 
 """

--- a/test/test_outvar_selectors.jl
+++ b/test/test_outvar_selectors.jl
@@ -250,6 +250,25 @@ end
     sliced_var =
         ClimaAnalysis.slice(var_2d_dim, dim2d = 3, by = ClimaAnalysis.Index())
     @test sliced_var.data == fill(3)
+
+    # Test slice with non-positive time values
+    time = [-2.0, -1.0, 0.0, 1.0]
+    var =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(long_name = "hi") |>
+        initialize
+
+    var_at_zero_time = ClimaAnalysis.slice(var, t = 0.0)
+    @test var_at_zero_time.attributes["slice_time_units"] == "s"
+    @test var_at_zero_time.attributes["long_name"] == "hi time = 0.0s"
+    @test var_at_zero_time.attributes["slice_time"] == "0.0"
+
+    var_at_neg_time = ClimaAnalysis.slice(var, t = -2.0)
+    @test var_at_neg_time.attributes["slice_time_units"] == "s"
+    @test var_at_neg_time.attributes["long_name"] == "hi time = -2.0s"
+    @test var_at_neg_time.attributes["slice_time"] == "-2.0"
+
 end
 
 @testset "Windowing" begin


### PR DESCRIPTION
closes #335 - When `slice` is used with an `OutputVar` with a non-positive time value, the long name would show an empty string for the value at which the `slice` was applied. This occurs because `seconds_to_prettystr` was returning an empty string for negative values. This commit fixes the bug by properly handling non-positive values in `seconds_to_prettystr`.