### PR TITLE
Add write_to_netcdf support for OutputVar

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -31,6 +31,7 @@ Catalog.available_vars(catalog::NCCatalog)
 ```@docs
 Var.OutputVar
 Var.read_var
+Var.write_to_netcdf
 Var.is_z_1D
 Base.isempty(var::OutputVar)
 Var.short_name

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -19,6 +19,19 @@ import ClimaAnalysis: OutputVar
 myfile = OutputVar("my_netcdf_file.nc", "myvar")
 ```
 
+## Writing to NetCDF
+
+`OutputVar`s can be written to NetCDF files using [`write_to_netcdf`](@ref).
+
+```julia
+ClimaAnalysis.write_to_netcdf("output.nc", var)
+```
+
+This creates a NetCDF file containing the data, dimensions, and attributes of the
+`OutputVar`. The name of the variable in the NetCDF file is taken from the `short_name`
+attribute of the `OutputVar`. If a file already exists at the target path, it will be
+overwritten.
+
 ## Physical units
 
 `OutputVar`s can contain information about their physical units. For


### PR DESCRIPTION
## Purpose 
closes #368 

This PR adds support for writing an `OutputVar` back to a NetCDF file via `write_to_netcdf`.
The goal is to enable round trip workflow where users can read data, perform analysis, and then persist the resulting variable for later use.


## To-do
- Implement OutputVar to NetCDF file
- Add tests for NetCDF write 
- Document the new functionality

## Content
- Added `write_to_netcdf(path, var)` to write an `OutputVar` to a NetCDF file, including its data, dimensions, and associated attributes.
- Introduced `_netcdf_safe_attrib` to convert attribute values to NetCDF-
  compatible types when writing.
- Added basic validation to ensure dimension consistency and `short_name` requirement for NetCDF output.
- Added tests covering I/O, replacement of existing files, preservation of numeric types , handling of NaN .
- updated the documentation.

## Notes on scalar variables
**Scalar (0D) variables:** A round-trip test for scalar `OutputVar`s (Test 7 in `test/test_Var.jl`) is currently commented out.
  When reading a scalar variable from NetCDF, `read_var` returns an empty, untyped `OrderedDict` for dimensions. This does not match the typed dictionary expected by the `OutputVar` constructor and results in a `MethodError` during the read step.

  Since this behavior originates in the existing read/constructor path and not in the new NetCDF writing logic, it was left unchanged here to keep this PR focused on issue #368. This can be addressed separately in a follow-up PR if desired.
  
  If there are any adjustments you’d like to see I’m happy to make those changes.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
