### PR TITLE
Replace Julia v1.9 with 1.12 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.9'
           - '1.10'
           - '1.11'
+          - '1.12'
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1.9', '1.10', '1.11']
+        version: ['1.10', '1.11', '1.12']
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@latest


### PR DESCRIPTION
This PR replaces Julia v.1.9 with v1.12 because the long term support release is Julia v1.10.10.