### PR TITLE
Add show methods for FlatVar and Metadata 

### DIFF
--- a/src/flat.jl
+++ b/src/flat.jl
@@ -333,3 +333,147 @@ function Base.getproperty(var::FlatVar, s::Symbol)
         return Base.getfield(var, s)
     end
 end
+
+"""
+    Base.show(io::IO, var::FlatVar)
+
+Pretty print the contents of an `FlatVar`.
+
+Print the attributes, dimension attributes, and dimensions that the data is defined
+over.
+"""
+
+function Base.show(io::IO, var::FlatVar)
+    # Print the key value pairs of attributes
+    printstyled(io, "Attributes:\n", bold = true, color = :green)
+    # Find spacing to pad out key of var.attributes
+    max_length_attribs =
+        maximum(length(x) for (x, _) in var.attributes; init = 0)
+    for (key, val) in var.attributes
+        print(io, "  " * rpad(key, max_length_attribs) * " => ")
+        printstyled(io, "$(val)\n", color = :light_cyan)
+    end
+
+    # Print the key value pairs of dimension attributes recursively
+    printstyled(io, "Dimension attributes:\n", bold = true, color = :green)
+    # Find spacing to pad out key of var.attributes
+    for (dim, dim_attrib) in var.dim_attributes
+        printstyled(io, "  $dim:\n", color = :light_green)
+        max_length_dim_attribs =
+            maximum(length(x) for (x, _) in dim_attrib; init = 0)
+        for (key, val) in dim_attrib
+            print(io, "    " * rpad(key, max_length_dim_attribs) * " => ")
+            printstyled(io, "$(val)\n", color = :light_cyan)
+        end
+    end
+
+    # Print the dimensions that the data is defined over
+    printstyled(io, "Data defined over:", bold = true, color = :green)
+    # Do not add a new line if there is nothing to print in var.dims
+    !isempty(var.dims) && print(io, "\n")
+    max_length_dims = maximum(length(x) for (x, _) in var.dims; init = 0)
+    for (i, (dim, array)) in enumerate(var.dims)
+        printstyled(io, "  " * rpad(dim, max_length_dims), color = :light_green)
+        print(io, " with ")
+        printstyled(io, "$(length(array)) ", color = :light_cyan)
+
+        # Print contents depending on size of the dimension
+        if length(array) >= 2
+            print(io, "elements")
+            sorted_at_all = issorted(array) || issorted(array, rev = true)
+            if sorted_at_all
+                print(io, " (")
+                printstyled(io, "$(array[begin])", color = :light_cyan)
+                print(io, " to ")
+                printstyled(io, "$(array[end])", color = :light_cyan)
+                print(io, ")")
+            else
+                print(io, " (")
+                printstyled(io, "not sorted", color = :red)
+                print(io, ")")
+            end
+        elseif length(array) == 1
+            print(io, "element")
+            print(io, " (")
+            printstyled(io, "$(array[begin])", color = :light_cyan)
+            print(io, ")")
+        elseif length(array) == 0
+            print(io, "element")
+        end
+        # Do not add a new line on the last dimension
+        if i != length(var.dims)
+            print(io, "\n")
+        end
+    end
+end
+
+"""
+    Base.show(io::IO, var::Metadata)
+
+Print the attributes, dimension attributes, and dimensions that the data is defined
+over.
+"""
+
+function Base.show(io::IO, var::Metadata)
+    # Print the key value pairs of attributes
+    printstyled(io, "Attributes:\n", bold = true, color = :green)
+    # Find spacing to pad out key of var.attributes
+    max_length_attribs =
+        maximum(length(x) for (x, _) in var.attributes; init = 0)
+    for (key, val) in var.attributes
+        print(io, "  " * rpad(key, max_length_attribs) * " => ")
+        printstyled(io, "$(val)\n", color = :light_cyan)
+    end
+
+    # Print the key value pairs of dimension attributes recursively
+    printstyled(io, "Dimension attributes:\n", bold = true, color = :green)
+    # Find spacing to pad out key of var.attributes
+    for (dim, dim_attrib) in var.dim_attributes
+        printstyled(io, "  $dim:\n", color = :light_green)
+        max_length_dim_attribs =
+            maximum(length(x) for (x, _) in dim_attrib; init = 0)
+        for (key, val) in dim_attrib
+            print(io, "    " * rpad(key, max_length_dim_attribs) * " => ")
+            printstyled(io, "$(val)\n", color = :light_cyan)
+        end
+    end
+
+    # Print the dimensions that the data is defined over
+    printstyled(io, "Data defined over:", bold = true, color = :green)
+    # Do not add a new line if there is nothing to print in var.dims
+    !isempty(var.dims) && print(io, "\n")
+    max_length_dims = maximum(length(x) for (x, _) in var.dims; init = 0)
+    for (i, (dim, array)) in enumerate(var.dims)
+        printstyled(io, "  " * rpad(dim, max_length_dims), color = :light_green)
+        print(io, " with ")
+        printstyled(io, "$(length(array)) ", color = :light_cyan)
+
+        # Print contents depending on size of the dimension
+        if length(array) >= 2
+            print(io, "elements")
+            sorted_at_all = issorted(array) || issorted(array, rev = true)
+            if sorted_at_all
+                print(io, " (")
+                printstyled(io, "$(array[begin])", color = :light_cyan)
+                print(io, " to ")
+                printstyled(io, "$(array[end])", color = :light_cyan)
+                print(io, ")")
+            else
+                print(io, " (")
+                printstyled(io, "not sorted", color = :red)
+                print(io, ")")
+            end
+        elseif length(array) == 1
+            print(io, "element")
+            print(io, " (")
+            printstyled(io, "$(array[begin])", color = :light_cyan)
+            print(io, ")")
+        elseif length(array) == 0
+            print(io, "element")
+        end
+        # Do not add a new line on the last dimension
+        if i != length(var.dims)
+            print(io, "\n")
+        end
+    end
+end


### PR DESCRIPTION
This PR adds show methods for FlatVar and Metadata, reusing the same code as that of OutputVar for the two show methods.

This could be improved by implementing a helper function that can be called by the show methods of the two. 

Fixes #349 