### PR TITLE
Clean up typos and missing type annotations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@ pr_var = get(catalog, "pr")
 
 - Fix bug with dimension attributes not being properly updated when using
   `select` or `select_view`.
+- Keep units for unary minus for `OutputVar`.
 
 v0.5.21
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@ pr_var = get(catalog, "pr")
 - Fix bug with dimension attributes not being properly updated when using
   `select` or `select_view`.
 - Keep units for unary minus for `OutputVar`.
+- Add missing type annotations.
 
 v0.5.21
 -------

--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ pr_var = get(catalog, "pr")
   `select` or `select_view`.
 - Keep units for unary minus for `OutputVar`.
 - Add missing type annotations.
+- Fix typos in docs.
 
 v0.5.21
 -------

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -131,7 +131,6 @@ obs_var = ClimaAnalysis.OutputVar(
     The keyword arguments `new_start_date` and `shift_by` are deprecated in versions of
     ClimaAnalysis after v0.5.21. Users are encouraged to use [`set_reference_date!`](@ref)
     and [`transform_dates!`](@ref) instead.
-"""
 
 Additionally, the function `shift_to_start_of_previous_month(var::OutputVar)` is provided to
 help with preprocessing. This function shifts the times in the time dimension to the start

--- a/src/Leaderboard.jl
+++ b/src/Leaderboard.jl
@@ -315,18 +315,16 @@ function read_rmses(csv_file::String, short_name::String; units = nothing)
 end
 
 """
-    function _index_convert(key2index, key::Colon)
+    _index_convert(key2index, key::Colon)
 
 Convert the symbol colon into an index for indexing.
 """
-function _index_convert(key2index, key::Colon)
+function _index_convert(key2index, ::Colon)
     return collect(values(key2index))
 end
 
 """
-    function _index_convert(key2index,
-                            indices::AbstractVector{I})
-                            where {I <: Integer}
+    _index_convert(key2index, key::AbstractString)
 
 Convert a string into an index for indexing.
 """
@@ -337,9 +335,10 @@ function _index_convert(key2index, key::AbstractString)
 end
 
 """
-    function _index_convert(key2index,
-                            keys::AbstractVector{S})
-                            where {S <: AbstractString}
+    _index_convert(
+        key2index,
+        keys::AbstractVector{S},
+    ) where {S <: AbstractString}
 
 Convert a vector of strings to indices for indexing.
 """
@@ -355,9 +354,7 @@ function _index_convert(
 end
 
 """
-    function _index_convert(key2index,
-                            indices::AbstractVector{I})
-                            where {I <: Integer}
+    _index_convert(key2index, index::Integer)
 
 Convert an integer to an index for indexing.
 """
@@ -368,9 +365,10 @@ function _index_convert(key2index, index::Integer)
 end
 
 """
-    function _index_convert(key2index,
-                            indices::AbstractVector{I})
-                            where {I <: Integer}
+    _index_convert(
+        key2index,
+        indices::AbstractVector{I},
+    ) where {I <: Integer}
 
 Convert a vector of integers to indices for indexing.
 """

--- a/src/Sim.jl
+++ b/src/Sim.jl
@@ -107,7 +107,7 @@ Return the short names of the variables found in the given `simdir`.
 available_vars(simdir::SimDir) = keys(simdir.vars) |> Set
 
 """
-    available_reductions(simdir::SimDir, short_name::String)
+    available_reductions(simdir::SimDir; short_name::String)
 
 Return the reductions available for the given variable in the given `simdir`.
 """
@@ -122,7 +122,7 @@ function available_reductions(simdir::SimDir; short_name::String)
 end
 
 """
-    available_periods(simdir::SimDir, short_name::String, reduction::String)
+    available_periods(simdir::SimDir; short_name::String, reduction::String)
 
 Return the periods associated to the given variable and reduction.
 """

--- a/src/Template.jl
+++ b/src/Template.jl
@@ -347,8 +347,8 @@ end
 
 Add data of `1:n` to `TemplateVar` where `n` is the product of the sizes of the dimensions.
 
-If `collected = false`, then `collect` is not called on the data and if `collected = true`,
-then `collect` is called on the data.
+If `collected = true`, then  `collect` is called on the data and if `collected = false`,
+then`collect` is not called on the data.
 
 Designed to be used with the pipe operator (`|>`).
 """
@@ -362,8 +362,8 @@ end
 
 Add data of `1:n` to `var` where `n` is the product of the sizes of the dimensions.
 
-If `collected = true`, then `collect` is not called on the data and if `collected = false`,
-then `collect` is called on the data.
+If `collected = true`, then  `collect` is called on the data and if `collected = false`,
+then`collect` is not called on the data.
 
 Designed to be used with function composition.
 """

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -459,8 +459,8 @@ end
 """
     find_season_and_year(date::Dates.DateTime)
 
-Return a tuple of the year and season belong to `date`. The variable `year` is
-an integer and `season` is a string.
+Return a tuple of the season and year belong to `date`. The variable `season` is
+a string and `year` is an integer.
 
 The months of the seasons are March to May, June to August, September to
 November, and December to February.

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -775,11 +775,13 @@ function Base.copy(var::OutputVar)
 end
 
 """
-    _reduce_over(reduction::F,
-                 dims,
-                 var::OutputVar,
-                 args...;
-                 kwargs...)
+    _reduce_over(
+        reduction::F,
+        dims,
+        var::OutputVar,
+        args...;
+        kwargs...,
+    )
 
 Apply the given reduction over multiple dimensions in `dims`.
 
@@ -843,7 +845,7 @@ Return a new OutputVar where the values on the latitudes are averaged arithmetic
 
 When `weighted` is `true`, weight the average over `cos(lat)`.
 """
-function average_lat(var; ignore_nan = true, weighted = false)
+function average_lat(var::OutputVar; ignore_nan = true, weighted = false)
     if weighted
         var = copy(var)
         lats = latitudes(var)
@@ -883,7 +885,7 @@ end
 Return a new OutputVar where the values on the latitudes are averaged arithmetically
 with weights of `cos(lat)`.
 """
-weighted_average_lat(var; ignore_nan = true) =
+weighted_average_lat(var::OutputVar; ignore_nan = true) =
     average_lat(var; ignore_nan, weighted = true)
 
 """
@@ -892,7 +894,7 @@ weighted_average_lat(var; ignore_nan = true) =
 
 Return a new OutputVar where the values on the longitudes are averaged arithmetically.
 """
-function average_lon(var; ignore_nan = true)
+function average_lon(var::OutputVar; ignore_nan = true)
     reduced_var =
         _reduce_over(ignore_nan ? nanmean : mean, longitude_name(var), var)
     _update_long_name_generic!(
@@ -909,7 +911,7 @@ end
 
 Return a new OutputVar where the values along the `x` dimension are averaged arithmetically.
 """
-function average_x(var; ignore_nan = true)
+function average_x(var::OutputVar; ignore_nan = true)
     reduced_var = _reduce_over(ignore_nan ? nanmean : mean, "x", var)
     _update_long_name_generic!(reduced_var, var, "x", "averaged")
     return reduced_var
@@ -920,7 +922,7 @@ end
 
 Return a new OutputVar where the values along the `y` dimension are averaged arithmetically.
 """
-function average_y(var; ignore_nan = true)
+function average_y(var::OutputVar; ignore_nan = true)
     reduced_var = _reduce_over(ignore_nan ? nanmean : mean, "y", var)
     _update_long_name_generic!(reduced_var, var, "y", "averaged")
     return reduced_var
@@ -932,7 +934,7 @@ end
 Return a new OutputVar where the values along both horizontal dimensions `x` and `y`
 are averaged arithmetically.
 """
-function average_xy(var; ignore_nan = true)
+function average_xy(var::OutputVar; ignore_nan = true)
     reduced_var = _average_dims(
         var,
         ("x", "y"),
@@ -952,7 +954,7 @@ function average_xy(var; ignore_nan = true)
 end
 
 """
-    weighted_average_lonlat(var; ignore_nan = true)
+    weighted_average_lonlat(var::OutputVar; ignore_nan = true)
 
 Return a new `OutputVar` where the values along the longitude and latitude dimensions
 are averaged arithmetically with weights of `cos(lat)` along the latitude dimension.
@@ -963,12 +965,12 @@ are averaged arithmetically with weights of `cos(lat)` along the latitude dimens
     values across both the longitude and latitude dimensions. In particular, the results
     differ when there are `NaN`s.
 """
-function weighted_average_lonlat(var; ignore_nan = true)
+function weighted_average_lonlat(var::OutputVar; ignore_nan = true)
     return average_lonlat(var; ignore_nan = ignore_nan, weighted = true)
 end
 
 """
-    average_lonlat(var; ignore_nan = true)
+    average_lonlat(var::OutputVar; ignore_nan = true)
 
 Return a new `OutputVar` where the values along the longitude and latitude dimensions
 are averaged arithmetically.
@@ -978,7 +980,7 @@ are averaged arithmetically.
     function computes the global average over all the values across both the longitude and
     latitude dimensions. In particular, the results will differ when there are `NaN`s.
 """
-function average_lonlat(var; ignore_nan = true, weighted = false)
+function average_lonlat(var::OutputVar; ignore_nan = true, weighted = false)
     lat_name = latitude_name(var)
     lon_name = longitude_name(var)
     !weighted &&
@@ -1035,10 +1037,12 @@ function average_lonlat(var; ignore_nan = true, weighted = false)
 end
 
 """
-    _average_dims(var,
-                  dims;
-                  ignore_nan = true,
-                  update_long_name = true)
+    _average_dims(
+        var::OutputVar,
+        dims;
+        ignore_nan = true,
+        update_long_name = true,
+    )
 
 Return a new `OutputVar` where the values along the dimensions in `dims` are averaged
 arithmetically.
@@ -1046,7 +1050,12 @@ arithmetically.
 If `update_long_name` is `true`, then the long name is updated by using
 `_update_long_name_generic!`.
 """
-function _average_dims(var, dims; ignore_nan = true, update_long_name = true)
+function _average_dims(
+    var::OutputVar,
+    dims;
+    ignore_nan = true,
+    update_long_name = true,
+)
     function reduction(data; dims, ignore_nan)
         return ignore_nan ? nanmean(data, dims = dims) : mean(data, dims = dims)
     end
@@ -1063,14 +1072,14 @@ end
 
 Return a new OutputVar where the values are averaged arithmetically in time.
 """
-function average_time(var; ignore_nan = true)
+function average_time(var::OutputVar; ignore_nan = true)
     reduced_var = _reduce_over(ignore_nan ? nanmean : mean, time_name(var), var)
     _update_long_name_generic!(reduced_var, var, time_name(var), "averaged")
     return reduced_var
 end
 
 """
-    variance_time(var; ignore_nan = true)
+    variance_time(var::OutputVar; ignore_nan = true, corrected = true)
 
 Return a new OutputVar where the values are the variances along the time dimension.
 
@@ -1078,7 +1087,7 @@ If `corrected` is `true`, then the variance is computed by dividing the sample m
 1`, whereas if `corrected` is `false`, then the variance is computed by dividing the sample
 mean by `n`, where `n` is the number of elements that the variance is being computed over.
 """
-function variance_time(var; ignore_nan = true, corrected = true)
+function variance_time(var::OutputVar; ignore_nan = true, corrected = true)
     reduced_var = _reduce_over(
         ignore_nan ? nanvar : Statistics.var,
         time_name(var),
@@ -1090,7 +1099,7 @@ function variance_time(var; ignore_nan = true, corrected = true)
 end
 
 """
-    variance_lon(var; ignore_nan = true)
+    variance_lon(var::OutputVar; ignore_nan = true, corrected = true)
 
 Return a new OutputVar where the values are the variances along the longitude dimension.
 
@@ -1098,7 +1107,7 @@ If `corrected` is `true`, then the variance is computed by dividing the sample m
 1`, whereas if `corrected` is `false`, then the variance is computed by dividing the sample
 mean by `n`, where `n` is the number of elements that the variance is being computed over.
 """
-function variance_lon(var; ignore_nan = true, corrected = true)
+function variance_lon(var::OutputVar; ignore_nan = true, corrected = true)
     reduced_var = _reduce_over(
         ignore_nan ? nanvar : Statistics.var,
         longitude_name(var),
@@ -1116,7 +1125,7 @@ function variance_lon(var; ignore_nan = true, corrected = true)
 end
 
 """
-    variance_lat(var; ignore_nan = true, corrected = true)
+    variance_lat(var::OutputVar; ignore_nan = true, corrected = true)
 
 Return a new OutputVar where the values are the variances along the latitude dimension.
 
@@ -1124,7 +1133,7 @@ If `corrected` is `true`, then the variance is computed by dividing the sample m
 1`, whereas if `corrected` is `false`, then the variance is computed by dividing the sample
 mean by `n`, where `n` is the number of elements that the variance is being computed over.
 """
-function variance_lat(var; ignore_nan = true, corrected = true)
+function variance_lat(var::OutputVar; ignore_nan = true, corrected = true)
     reduced_var = _reduce_over(
         ignore_nan ? nanvar : Statistics.var,
         latitude_name(var),
@@ -1229,7 +1238,7 @@ This is useful to center the global projection to the 180 meridian instead of th
     This function is deprecated and users are encouraged to use
     [`shift_longitude`](@ref) instead.
 """
-function center_longitude!(var, lon)
+function center_longitude!(var::OutputVar, lon)
     Base.depwarn(
         "This function is deprecated and may be incorrect. Users are encouraged to use
         `center_longitude(var, lower_lon, upper_lon; shift_by = 0.0)` instead.",
@@ -1259,7 +1268,7 @@ function center_longitude!(var, lon)
 end
 
 """
-    shift_longitude(var, lower_lon, upper_lon; shift_by = 0.0)
+    shift_longitude(var::OutputVar, lower_lon, upper_lon)
 
 Shift the longitudes in `var` to `lower_lon` to `upper_lon` degrees.
 
@@ -1278,7 +1287,7 @@ To shift from -180 to 180 degrees to 0 to 360 degrees, use
 `shift_longitude(var, 0.0, 360.0)` and to shift from 0 to 360 degrees to -180 to 180
 degrees, use `shift_longitude(var, -180.0, 180.0)`.
 """
-function shift_longitude(var, lower_lon, upper_lon)
+function shift_longitude(var::OutputVar, lower_lon, upper_lon)
     width = upper_lon - lower_lon
     width ≈ 2π &&
         @warn "Result may be incorrect if radians are used instead of degrees"
@@ -2004,7 +2013,7 @@ The year can be found by `var.attributes["year"]`, which returns a vector of yea
 strings. The convention used is that the second month of the season determines the year. For
 example, the year of DJF is the same year as Janauary.
 """
-function average_season_across_time(var; ignore_nan = true)
+function average_season_across_time(var::OutputVar; ignore_nan = true)
     season_vars = split_by_season_across_time(var)
     nonempty_season_vars = filter(!isempty, season_vars)
     season_names =
@@ -2317,9 +2326,11 @@ function global_rmse(sim::OutputVar, obs::OutputVar; mask = nothing)
 end
 
 """
-    _dates_to_seconds(var::OutputVar;
-                      new_start_date = nothing,
-                      shift_by = identity)
+    _dates_to_seconds(
+        var::OutputVar;
+        new_start_date = nothing,
+        shift_by = identity,
+    )
 
 Convert dates in time dimension to seconds with respect to the first date in the time
 dimension array or the `new_start_date`.

--- a/src/masks.jl
+++ b/src/masks.jl
@@ -242,16 +242,18 @@ function apply_oceanmask(var::OutputVar; threshold = 0.5)
 end
 
 """
-    make_lonlat_mask(var;
-                     set_to_val = nothing,
-                     true_val = NaN,
-                     false_val = 1.0)
+    make_lonlat_mask(
+        var;
+        set_to_val = nothing,
+        true_val = NaN,
+        false_val = 1.0,
+    )
 
 Return a masking function that takes in a `OutputVar` and mask the data using `var.data`.
 
 The parameter `set_to_val` is a function that takes in an element of `var.data` and return
 `true` or `false`. If `set_to_val` returns `true`, then the value will be `true_val` in the
-mask and if `set_to_nan` returns `false`, then the value will be `false_val` in the mask.
+mask and if `set_to_val` returns `false`, then the value will be `false_val` in the mask.
 
 If `set_to_val` is `nothing`, then no transformation is done and `var.data` is used. This is
 helpful if `var.data` is already an array of NaNs and ones or an array of zeros and ones.

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -269,7 +269,7 @@ function find_corresponding_dim_name(dim_name::AbstractString, dim_names)
 end
 
 """
-    find_corresponding_dim_name(dim_name::AbstractString, var)
+    find_corresponding_dim_name_in_var(dim_name::AbstractString, var)
 
 Find the corresponding dimension name in `var`'s dimension that matches `dim_name`.
 

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -30,8 +30,8 @@ export times,
 """
     _dim_name(dim_names, allowed_names)
 
-Return the `dim_name` within `dim_names` that is contained in `allowed_names`.
-Return `nothing` is not available.
+Return the index of the first element in `allowed_names` that is contained in `dim_names`.
+Return `nothing` if no element of `allowed_names` is found in `dim_names`.
 
 Example
 ==========
@@ -291,7 +291,7 @@ julia> keys(var.dims)
 julia> ClimaAnalysis.Var.find_corresponding_dim_name_in_var("t", var)
 "time"
 
-julia> ClimaAnalysis.Var.find_corresponding_dim_name("potatoes", var)
+julia> ClimaAnalysis.Var.find_corresponding_dim_name_in_var("potatoes", var)
 "potatoes"
 ```
 """

--- a/src/outvar_operators.jl
+++ b/src/outvar_operators.jl
@@ -3,7 +3,11 @@
 
 Add methods to overload the given binary `op`erator for `OutputVars` and `Real`s.
 
-Attributes that are not `short_name`, `long_name`, are discarded in the process.
+Attributes that are not `short_name`, `long_name`, `start_date`, and `units` are discarded
+in the process.
+
+The `start_date` and `units` are only kept if the start date and units are the same
+respectively.
 """
 macro overload_binary_op(op)
     quote
@@ -170,6 +174,7 @@ Generate a method to overload the unary operator `op` for `OutputVar`.
 Handles attributes `short_name`, `long_name`: Prepends the operator name, e.g., "log(Temperature)".
 """
 macro overload_unary_op(op)
+    keep_attrs = op == :(-) ? ("start_date", "units") : ("start_date",)
     esc(
         quote
             function Base.$op(x::OutputVar)
@@ -186,7 +191,7 @@ macro overload_unary_op(op)
                     end
                 end
 
-                keep_attributes = ("start_date",)
+                keep_attributes = $keep_attrs
                 for attr in keep_attributes
                     if haskey(x.attributes, attr)
                         ret_attributes[attr] = x.attributes[attr]

--- a/src/outvar_operators.jl
+++ b/src/outvar_operators.jl
@@ -171,7 +171,10 @@ end
 
 Generate a method to overload the unary operator `op` for `OutputVar`.
 
-Handles attributes `short_name`, `long_name`: Prepends the operator name, e.g., "log(Temperature)".
+Handles the attributes `short_name`, `long_name`, `start_date`, and `units` and prepends the
+operator name, e.g., "log(Temperature)".
+
+The attribute `units` is only kept for unary minus.
 """
 macro overload_unary_op(op)
     keep_attrs = op == :(-) ? ("start_date", "units") : ("start_date",)

--- a/src/outvar_selectors.jl
+++ b/src/outvar_selectors.jl
@@ -380,7 +380,7 @@ function select(var::OutputVar; by = NearestValue(), kwargs...)
 end
 
 """
-    view_select(var::OutputVar, by = NearestValue(), kwargs...)
+    view_select(var::OutputVar; by = NearestValue(), kwargs...)
 
 Return a new `OutputVar` by selecting indices or values according to `by` across dimensions
 as defined by the keyword arguments. The data of the returned `OutputVar` is a view of
@@ -459,10 +459,12 @@ function _select(var::OutputVar, by::AbstractSelector; kwargs...)
 end
 
 """
-    _select_indices(var::OutputVar,
-                    by::AbstractSelector,
-                    dim_name,
-                    indices_or_vals)
+    _select_indices(
+        var::OutputVar,
+        by::AbstractSelector,
+        dim_name,
+        indices_or_vals,
+    )
 
 Return the indices for `var.data` corresponding to the given `indices_or_vals` in the
 specified dimension.

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -461,59 +461,61 @@ end
 
     @testset "Unary Operations" begin
         # Logarithm (log)
-        log_var1 = log(var1)
-        @test log_var1.data == log.(var1.data)
-        @test ClimaAnalysis.short_name(log_var1) == "log(bob)"
-        @test ClimaAnalysis.long_name(log_var1) == "log(hi)"
-        @test log_var1.attributes == Dict(
+        var4 = ClimaAnalysis.set_units(var1, "m^2")
+        log_var4 = log(var4)
+        @test log_var4.data == log.(var4.data)
+        @test ClimaAnalysis.short_name(log_var4) == "log(bob)"
+        @test ClimaAnalysis.long_name(log_var4) == "log(hi)"
+        @test log_var4.attributes == Dict(
             "short_name" => "log(bob)",
             "long_name" => "log(hi)",
             "start_date" => "2008",
         )
-        @test log_var1.dims == var1.dims
-        @test log_var1.dim_attributes == var1.dim_attributes
+        @test log_var4.dims == var4.dims
+        @test log_var4.dim_attributes == var4.dim_attributes
 
         # Exponential (exp)
-        exp_var1 = exp(var1)
-        @test exp_var1.data ≈ exp.(var1.data) # Use ≈ for potential Float inaccuracies
-        @test ClimaAnalysis.short_name(exp_var1) == "exp(bob)"
-        @test ClimaAnalysis.long_name(exp_var1) == "exp(hi)"
+        exp_var4 = exp(var4)
+        @test exp_var4.data ≈ exp.(var4.data) # Use ≈ for potential Float inaccuracies
+        @test ClimaAnalysis.short_name(exp_var4) == "exp(bob)"
+        @test ClimaAnalysis.long_name(exp_var4) == "exp(hi)"
 
         # Sine (sin)
-        sin_var1 = sin(var1)
-        @test sin_var1.data == sin.(var1.data)
-        @test ClimaAnalysis.short_name(sin_var1) == "sin(bob)"
-        @test ClimaAnalysis.long_name(sin_var1) == "sin(hi)"
+        sin_var4 = sin(var4)
+        @test sin_var4.data == sin.(var4.data)
+        @test ClimaAnalysis.short_name(sin_var4) == "sin(bob)"
+        @test ClimaAnalysis.long_name(sin_var4) == "sin(hi)"
 
         # Cosine (cos)
-        cos_var1 = cos(var1)
-        @test cos_var1.data == cos.(var1.data)
-        @test ClimaAnalysis.short_name(cos_var1) == "cos(bob)"
-        @test ClimaAnalysis.long_name(cos_var1) == "cos(hi)"
+        cos_var4 = cos(var4)
+        @test cos_var4.data == cos.(var4.data)
+        @test ClimaAnalysis.short_name(cos_var4) == "cos(bob)"
+        @test ClimaAnalysis.long_name(cos_var4) == "cos(hi)"
 
         # Tangent (tan)
-        tan_var1 = tan(var1)
-        @test tan_var1.data == tan.(var1.data)
-        @test ClimaAnalysis.short_name(tan_var1) == "tan(bob)"
-        @test ClimaAnalysis.long_name(tan_var1) == "tan(hi)"
+        tan_var4 = tan(var4)
+        @test tan_var4.data == tan.(var4.data)
+        @test ClimaAnalysis.short_name(tan_var4) == "tan(bob)"
+        @test ClimaAnalysis.long_name(tan_var4) == "tan(hi)"
 
         # Square Root (sqrt)
-        sqrt_var1 = sqrt(var1)
-        @test sqrt_var1.data == sqrt.(var1.data)
-        @test ClimaAnalysis.short_name(sqrt_var1) == "sqrt(bob)"
-        @test ClimaAnalysis.long_name(sqrt_var1) == "sqrt(hi)"
+        sqrt_var4 = sqrt(var4)
+        @test sqrt_var4.data == sqrt.(var4.data)
+        @test ClimaAnalysis.short_name(sqrt_var4) == "sqrt(bob)"
+        @test ClimaAnalysis.long_name(sqrt_var4) == "sqrt(hi)"
 
         # Unary Minus (-)
-        neg_var1 = -var1
-        @test neg_var1.data == -(var1.data)
-        @test ClimaAnalysis.short_name(neg_var1) == "-(bob)" # Macro uses string(op)
-        @test ClimaAnalysis.long_name(neg_var1) == "-(hi)"
-        @test neg_var1.attributes == Dict(
+        neg_var4 = -var4
+        @test neg_var4.data == -(var4.data)
+        @test ClimaAnalysis.short_name(neg_var4) == "-(bob)" # Macro uses string(op)
+        @test ClimaAnalysis.long_name(neg_var4) == "-(hi)"
+        @test neg_var4.attributes == Dict(
             "short_name" => "-(bob)",
             "long_name" => "-(hi)",
             "start_date" => "2008",
+            "units" => "m^2",
         )
-        @test neg_var1.dims == var1.dims
+        @test neg_var4.dims == var4.dims
     end
 end
 


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaAnalysis.jl/issues/374, closes https://github.com/CliMA/ClimaAnalysis.jl/issues/365

This PR keeps units for unary minus for `OutputVar` (flipping the sign of the data is common for postprocessing), adding missing type annotations, and fixing typos in the docs.