### PR TITLE
Add getters for dimension names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@ pr_var = get(catalog, "pr")
 - The in-place version of `set_units` is now available as `set_units!`.
 - The in-place version of `transform_dates` is now available as
   `transform_dates!`.
+- The names of the dimensions of a `OutputVar` can be retrieved with
+  `dim_names`.
 
 ## Bug fixes
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -36,6 +36,7 @@ Var.is_z_1D
 Base.isempty(var::OutputVar)
 Var.short_name
 Var.long_name
+Var.dim_names
 Var.units
 Var.has_units
 Var.remake

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -158,6 +158,10 @@ times(ts_max_lat_averaged_sliced) =
  43200.0
 ```
 
+!!! note "Retrieving dimension names"
+    In versions of ClimaAnalysis after v0.5.21, you can get the names of
+    the dimensions of a `OutputVar` with [`dim_names`](@ref).
+
 `OutputVar`s can be evaluated on arbitrary points. For instance
 ``` julia-repl
 julia> ts_max([12000., 23., 45., 1200.])

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -43,6 +43,7 @@ export OutputVar,
     center_longitude!,
     short_name,
     long_name,
+    dim_names,
     units,
     dim_units,
     range_dim,
@@ -534,6 +535,15 @@ If not available, return an empty string.
 """
 function long_name(var::HasDimAndAttribs)
     get(var.attributes, "long_name", "")
+end
+
+"""
+    dim_names(var::OutputVar)
+
+Return an iterable of the names of the dimensions of `var`.
+"""
+function dim_names(var::HasDimAndAttribs)
+    return keys(var.dims)
 end
 
 """
@@ -1522,7 +1532,7 @@ example, dimensions with names `lon` and `long` are identified as the longitude 
 """
 function Base.permutedims(var::OutputVar, perm)
     # Get the conventional dim names for var and perm
-    conventional_dim_name_var = conventional_dim_name.(keys(var.dims))
+    conventional_dim_name_var = conventional_dim_name.(dim_names(var))
     conventional_dim_name_perm = conventional_dim_name.(collect(perm))
 
     # Check if the dimensions are the same (order does not matter)
@@ -1545,7 +1555,7 @@ function Base.permutedims(var::OutputVar, perm)
     # ret_dim_attribs
     ret_dim_attribs = empty(var.dim_attributes)
     var_dim_attribs = var.dim_attributes |> deepcopy
-    var_dim_names = collect(keys(var.dims))
+    var_dim_names = collect(dim_names(var))
     for idx in reorder_indices
         dim_name = var_dim_names[idx]
         haskey(var_dim_attribs, dim_name) &&
@@ -2649,7 +2659,7 @@ See also in-place [`reverse_dim!`](@ref).
 function reverse_dim(var::OutputVar, dim_name)
     # Check if dim_name exists
     !haskey(var.dims, dim_name) &&
-        error("Var does not have dimension $dim_name, found $(keys(var.dims))")
+        error("Var does not have dimension $dim_name, found $(dim_names(var))")
     # Check if array is 1D
     ndims(var.dims[dim_name]) != 1 &&
         error("Can only reverse 1D array for dimensions")
@@ -2669,7 +2679,7 @@ interpolant can be made.
 function reverse_dim!(var::OutputVar, dim_name)
     # Check if dim_name exists
     !haskey(var.dims, dim_name) &&
-        error("Var does not have dimension $dim_name, found $(keys(var.dims))")
+        error("Var does not have dimension $dim_name, found $(dim_names(var))")
     # Check if array is 1D
     ndims(var.dims[dim_name]) != 1 &&
         error("Can only reverse 1D array for dimensions")

--- a/src/flat.jl
+++ b/src/flat.jl
@@ -75,7 +75,7 @@ function flatten(
 
     # Filter unnecessary dimension names
     dims = conventional_dim_name.(dims)
-    var_dims = conventional_dim_name.(collect(keys(var.dims)))
+    var_dims = conventional_dim_name.(collect(dim_names(var)))
     dims = Tuple(
         find_corresponding_dim_name_in_var(dim, var) for
         dim in dims if dim in var_dims
@@ -83,11 +83,11 @@ function flatten(
 
     # Check that all dimensions are present
     length(dims) == length(var.dims) || error(
-        "All the dimensions in var ($(keys(var.dims))) are not present in dims ($dims)",
+        "All the dimensions in var ($(dim_names(var))) are not present in dims ($dims)",
     )
 
     # To flatten data, we need to permute, vectorize, and mask the data
-    perm = Tuple(indexin(dims, collect(keys(var.dims))))
+    perm = Tuple(indexin(dims, collect(dim_names(var))))
     permute_data = PermutedDimsArray(var.data, perm)
     vec_data = vec(permute_data)
 
@@ -145,9 +145,9 @@ Ordering of the dimensions does not matter.
 """
 function flatten(var::OutputVar, metadata::Metadata)
     # Check dimensions are the same in metadata and var
-    Set(conventional_dim_name.(keys(var.dims))) ==
+    Set(conventional_dim_name.(dim_names(var))) ==
     Set(conventional_dim_name.(keys(metadata.dims))) || error(
-        "Dimensions in var ($(keys(var.dims))) is not the same as the dimensions in the metadata ($(keys(metadata.dims)))",
+        "Dimensions in var ($(dim_names(var))) is not the same as the dimensions in the metadata ($(keys(metadata.dims)))",
     )
 
     # Instead of trying to determine whether dates or times should be used, we try dates
@@ -162,7 +162,7 @@ function flatten(var::OutputVar, metadata::Metadata)
     end
 
     # Check the dimension arrays are the same
-    for var_dim_name in keys(var.dims)
+    for var_dim_name in dim_names(var)
         md_dim_name = find_corresponding_dim_name_in_var(var_dim_name, metadata)
         if conventional_dim_name(var_dim_name) != "time"
             all(isapprox(var.dims[var_dim_name], metadata.dims[md_dim_name])) ||
@@ -177,7 +177,7 @@ function flatten(var::OutputVar, metadata::Metadata)
     end
 
     # Check the units of the dimensions are the same
-    for var_dim_name in keys(var.dims)
+    for var_dim_name in dim_names(var)
         md_dim_name = find_corresponding_dim_name_in_var(var_dim_name, metadata)
         var_dim_units = dim_units(var, var_dim_name)
         md_dim_units = dim_units(metadata, md_dim_name)

--- a/src/outvar_dimensions.jl
+++ b/src/outvar_dimensions.jl
@@ -51,7 +51,7 @@ end
 Return whether `var` has a `time` dimension.
 """
 has_time(var::HasDimAndAttribs) =
-    !isnothing(_dim_name(keys(var.dims), TIME_NAMES))
+    !isnothing(_dim_name(dim_names(var), TIME_NAMES))
 
 """
     has_date(var::OutputVar)
@@ -59,7 +59,7 @@ has_time(var::HasDimAndAttribs) =
 Return whether `var` has a `date` dimension.
 """
 has_date(var::HasDimAndAttribs) =
-    !isnothing(_dim_name(keys(var.dims), DATE_NAMES))
+    !isnothing(_dim_name(dim_names(var), DATE_NAMES))
 
 """
     has_longitude(var::OutputVar)
@@ -67,7 +67,7 @@ has_date(var::HasDimAndAttribs) =
 Return whether `var` has a `longitude` dimension.
 """
 has_longitude(var::HasDimAndAttribs) =
-    !isnothing(_dim_name(keys(var.dims), LONGITUDE_NAMES))
+    !isnothing(_dim_name(dim_names(var), LONGITUDE_NAMES))
 
 """
     has_latitude(var::OutputVar)
@@ -75,7 +75,7 @@ has_longitude(var::HasDimAndAttribs) =
 Return whether `var` has a `latitude` dimension.
 """
 has_latitude(var::HasDimAndAttribs) =
-    !isnothing(_dim_name(keys(var.dims), LATITUDE_NAMES))
+    !isnothing(_dim_name(dim_names(var), LATITUDE_NAMES))
 
 """
     has_altitude(var::OutputVar)
@@ -83,7 +83,7 @@ has_latitude(var::HasDimAndAttribs) =
 Return whether `var` has a `altitude` dimension.
 """
 has_altitude(var::HasDimAndAttribs) =
-    !isnothing(_dim_name(keys(var.dims), ALTITUDE_NAMES))
+    !isnothing(_dim_name(dim_names(var), ALTITUDE_NAMES))
 
 """
     has_pressure(var::OutputVar)
@@ -91,7 +91,7 @@ has_altitude(var::HasDimAndAttribs) =
 Return whether `var` has a `pressure` dimension.
 """
 has_pressure(var::HasDimAndAttribs) =
-    !isnothing(_dim_name(keys(var.dims), PRESSURE_NAMES))
+    !isnothing(_dim_name(dim_names(var), PRESSURE_NAMES))
 
 """
     find_dim_name(dim_names::Iterable, allowed_names::Iterable)
@@ -118,7 +118,7 @@ end
 
 Return the name of the `time` dimension in `var`.
 """
-time_name(var::HasDimAndAttribs) = find_dim_name(keys(var.dims), TIME_NAMES)
+time_name(var::HasDimAndAttribs) = find_dim_name(dim_names(var), TIME_NAMES)
 
 """
     times(var::OutputVar)
@@ -132,7 +132,7 @@ times(var::HasDimAndAttribs) = var.dims[time_name(var)]
 
 Return the name of the `date` dimension in `var`.
 """
-date_name(var::HasDimAndAttribs) = find_dim_name(keys(var.dims), DATE_NAMES)
+date_name(var::HasDimAndAttribs) = find_dim_name(dim_names(var), DATE_NAMES)
 
 """
     dates(var::OutputVar)
@@ -166,7 +166,7 @@ end
 Return the name of the `longitude` dimension in `var`.
 """
 longitude_name(var::HasDimAndAttribs) =
-    find_dim_name(keys(var.dims), LONGITUDE_NAMES)
+    find_dim_name(dim_names(var), LONGITUDE_NAMES)
 
 """
     longitudes(var::OutputVar)
@@ -181,7 +181,7 @@ longitudes(var::HasDimAndAttribs) = var.dims[longitude_name(var)]
 Return the name of the `latitude` dimension in `var`.
 """
 latitude_name(var::HasDimAndAttribs) =
-    find_dim_name(keys(var.dims), LATITUDE_NAMES)
+    find_dim_name(dim_names(var), LATITUDE_NAMES)
 
 """
     latitudes(var::OutputVar)
@@ -196,7 +196,7 @@ latitudes(var::HasDimAndAttribs) = var.dims[latitude_name(var)]
 Return the name of the `altitude` dimension in `var`.
 """
 altitude_name(var::HasDimAndAttribs) =
-    find_dim_name(keys(var.dims), ALTITUDE_NAMES)
+    find_dim_name(dim_names(var), ALTITUDE_NAMES)
 
 """
     altitudes(var::OutputVar)
@@ -211,7 +211,7 @@ altitudes(var::HasDimAndAttribs) = var.dims[altitude_name(var)]
 Return the name of the `pressure` dimension in `var`.
 """
 pressure_name(var::HasDimAndAttribs) =
-    find_dim_name(keys(var.dims), PRESSURE_NAMES)
+    find_dim_name(dim_names(var), PRESSURE_NAMES)
 
 """
     pressures(var::OutputVar)
@@ -285,7 +285,7 @@ Example
 ==========
 
 ```julia-repl
-julia> keys(var.dims)
+julia> ClimaAnalysis.dim_names(var)
 ("lon", "lat", "time", "potatoes")
 
 julia> ClimaAnalysis.Var.find_corresponding_dim_name_in_var("t", var)
@@ -297,11 +297,11 @@ julia> ClimaAnalysis.Var.find_corresponding_dim_name_in_var("potatoes", var)
 """
 function find_corresponding_dim_name_in_var(dim_name::AbstractString, var)
     dim_name_in_var = try
-        find_corresponding_dim_name(dim_name, keys(var.dims))
+        find_corresponding_dim_name(dim_name, dim_names(var))
     catch
         dim_name
     end
     haskey(var.dims, dim_name_in_var) ||
-        error("Var does not have dimension $dim_name, found $(keys(var.dims))")
+        error("Var does not have dimension $dim_name, found $(dim_names(var))")
     return dim_name_in_var
 end

--- a/src/outvar_selectors.jl
+++ b/src/outvar_selectors.jl
@@ -1,3 +1,5 @@
+import ClimaAnalysis
+
 export slice,
     window,
     select,
@@ -17,7 +19,7 @@ An object that determines which indices are selected.
 
 The function has to have the signature
 `get_index(var, dim_name, idx_or_val, ::AbstractSelector)` and return a single index. You
-can assume that `dim_name` is in `keys(var.dims)`.
+can assume that `dim_name` is in `ClimaAnalysis.dim_names(var)`.
 
 The function `get_index` is used by [`slice`](@ref) and [`window`](@ref). For instance, if
 you use `ClimaAnalysis.slice(var, time = 2)`, then `dim_name` is `time`, and `idx_or_val` is
@@ -431,7 +433,7 @@ function _select(var::OutputVar, by::AbstractSelector; kwargs...)
     )
 
     # Reorder dimensions
-    var_dim_names = collect(keys(var.dims))
+    var_dim_names = collect(ClimaAnalysis.dim_names(var))
     all_indices = ntuple(length(var.dims)) do i
         var_dim_name = var_dim_names[i]
         dim_idx = findfirst(==(var_dim_name), dim_names)

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -519,6 +519,24 @@ end
     end
 end
 
+@testset "Dimension names" begin
+    # Empty OutputVar (no dimensions)
+    var_no_dims = TemplateVar() |> initialize
+    @test isempty(ClimaAnalysis.dim_names(var_no_dims))
+
+    # 1D OutputVar
+    var_1d = TemplateVar() |> add_dim("longitude", [0.0]) |> initialize
+    @test collect(ClimaAnalysis.dim_names(var_1d)) == ["longitude"]
+
+    # 2D OutputVar
+    var_2d =
+        TemplateVar() |>
+        add_dim("lon", [0.0]) |>
+        add_dim("lat", [1.0]) |>
+        initialize
+    @test collect(ClimaAnalysis.dim_names(var_2d)) == ["lon", "lat"]
+end
+
 @testset "Units of binary operations" begin
     time = [0.0]
     template = TemplateVar() |> add_dim("time", time, units = "s")


### PR DESCRIPTION
This PR adds getters for dimension names. Users would use `keys(var.dims)` to get the dimension names, so users can now do `Var.dim_names(var)` instead.

This PR used to include a getter for the dimension values, but that function was removed. That functionality was accomplished by `longitudes`, `latitudes`, etc.
