### PR TITLE
Prevent dependabot from pushing doc previews

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -42,4 +42,11 @@ makedocs(;
     ],
 )
 
-deploydocs(; repo = "github.com/CliMA/ClimaAnalysis.jl", push_preview = true)
+deploydocs(;
+    repo = "github.com/CliMA/ClimaAnalysis.jl",
+    # Only push if all the relevant environment variables are defined
+    push_preview = push_preview = all(
+        !isempty,
+        (get(ENV, "GITHUB_TOKEN", ""), get(ENV, "DOCUMENTER_KEY", "")),
+    ),
+)


### PR DESCRIPTION
Without this commit, Dependabot will try to deploy docs and fail due to missing environment variables. See
https://github.com/JuliaDocs/Documenter.jl/issues/2048 which suggests the solution used in this commit.
