### PR TITLE
Add basic Makie conversions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,23 @@ The resulting `OutputVar` has a time dimension containing the first time value
 of `var`. For more information, see the section "Split-Apply-Combine" in the
 documentation.
 
+## Makie integration
+
+With this release, `Makie` functions such as `plot` and `surface` can now be
+used with `OutputVar`s.
+
+```julia
+import CairoMakie
+import ClimaAnalysis
+
+# This automatically work with one dimensional and two dimensional OutputVars
+CairoMakie.plot(var)
+
+fig = Makie.Figure()
+Makie.surface(fig[1, 1], var)
+Makie.save("surface_plot.png", fig)
+```
+
 ## Minor additions
 
 - The number of dimensions of a `OutputVar` can be accessed with `ndims`.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,7 +6,7 @@ GeoMakie = "db073c08-6b98-4ee5-b6a4-5efafb3259c6"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
-CairoMakie = "0.15"
+CairoMakie = "0.15.11"
 Documenter = "1"
 GeoMakie = "0.7.3"
 OrderedCollections = "1.3"

--- a/docs/src/visualize.md
+++ b/docs/src/visualize.md
@@ -125,3 +125,62 @@ CairoMakie.save("myfigure.pdf", fig)
 The output produces something like:
 
 ![bias_with_custom_mask_plot](./assets/plot_bias_with_custom_mask.png)
+
+### Makie integration
+
+```@setup makie_integration
+import ClimaAnalysis.Template:
+    TemplateVar,
+    make_template_var,
+    add_attribs,
+    add_dim,
+    add_data,
+    one_to_n_data,
+    initialize
+
+lat = -90.0:1.0:90.0
+lon = -180:1.0:180.0
+data2d = [cos(x / 90) * sin(y / 180) for x in lat, y in lon]
+var2d =
+    TemplateVar() |>
+    add_dim("lat", lat, units = "degrees") |>
+    add_dim("lon", lon, units = "degrees") |>
+    add_attribs(; long_name = "Air temperature", short_name = "ta", units = "K") |>
+    add_data(; data = data2d) |>
+    initialize
+```
+
+In versions of ClimaAnalysis after v0.5.22, Makie functions can be used natively
+with `OutputVar`s. In the example below, we use the `CairoMakie` backend and the
+`CairoMakie.plot` function to plot `var`. The type of the plot is automatically
+determined by the number of dimensions of the `OutputVar`. This supports
+`OutputVar` representing one dimensional or two dimensional data.
+
+```@example makie_integration
+import ClimaAnalysis
+import CairoMakie
+
+CairoMakie.plot(var2d; colormap = :vik10)
+```
+
+You can also use other plotting functions in `Makie` such as `heatmap` and
+`lines`. In this example, we use `heatmap` to plot a `OutputVar` with the
+longitude and latitude dimensions and `lines` to plot a weighted
+latitude-averaged `OutputVar`. You can expect most plotting functions from
+`Makie` to work out of the box.
+
+```@example makie_integration
+fig = CairoMakie.Figure(; size = (1000, 400))
+# If no axis is provided, then a default axis is added
+CairoMakie.heatmap(fig[1,1], var2d)
+
+# You can make your own axis for more customization
+lat_weighted_var = ClimaAnalysis.weighted_average_lat(var2d)
+long_name = ClimaAnalysis.long_name(lat_weighted_var)
+lon_units = ClimaAnalysis.dim_units(lat_weighted_var, "longitude")
+short_name = ClimaAnalysis.short_name(lat_weighted_var)
+var_units = ClimaAnalysis.units(lat_weighted_var)
+ax = CairoMakie.Axis(fig[1, 2], title = long_name, xlabel = "Longitude ($lon_units)", ylabel = "$short_name ($var_units)")
+CairoMakie.lines!(ax, lat_weighted_var; color = :blue)
+fig
+```

--- a/ext/ClimaAnalysisMakieExt.jl
+++ b/ext/ClimaAnalysisMakieExt.jl
@@ -906,4 +906,130 @@ function Visualize.plot_leaderboard!(
     )
 end
 
+"""
+    Makie.convert_arguments(
+        P::Makie.PointBased,
+        var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 1}},
+    ) where {T1, T2}
+
+Take a `OutputVar` representing one dimensional data and return the values of
+the dimension and the data.
+"""
+function Makie.convert_arguments(
+    P::Makie.PointBased,
+    var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 1}},
+) where {T1, T2}
+    Makie.convert_arguments(P, last(first(var.dims)), var.data)
+end
+
+"""
+    Makie.convert_arguments(
+        P::Makie.GridBased,
+        var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 2}},
+    ) where {T1, T2}
+
+Take a `OutputVar` representing two dimensional data and return the values of
+the dimensions and the data.
+
+If `var` has a longitude and latitude dimensions, then the dimensions of `var`
+are permuted to match the order of longitude and latitude.
+"""
+function Makie.convert_arguments(
+    P::Makie.GridBased,
+    var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 2}},
+) where {T1, T2}
+    # GeoMakie expects lon and lat when plotting
+    if ClimaAnalysis.has_longitude(var) && ClimaAnalysis.has_latitude(var)
+        dimnames =
+            ClimaAnalysis.conventional_dim_name.(ClimaAnalysis.dim_names(var))
+        dimnames == ("longitude", "latitude") ||
+            (var = permutedims(var, ("lon", "lat")))
+    end
+    dim_vecs = last.(collect(var.dims))
+    Makie.convert_arguments(P, dim_vecs[1], dim_vecs[2], var.data)
+end
+
+"""
+    Makie.plottype(var::ClimaAnalysis.OutputVar)
+
+Specify the type of plot for `var` depending on the number of dimensions.
+
+This allows for `Makie.plot` and `Makie.plot!` to be used with a `OutputVar`.
+"""
+function Makie.plottype(var::ClimaAnalysis.OutputVar)
+    N = ndims(var.data)
+    if N == 1
+        Makie.Lines
+    elseif N == 2
+        Makie.Heatmap
+    else
+        error(
+            "Plotting a OutputVar with $N dimensions is not supported with Makie.plot or Makie.plot!",
+        )
+    end
+end
+
+# Makie.preferred_axis_attributes was introduced in Makie v0.24.11
+@static if pkgversion(Makie) >= v"0.24.11"
+    # This is not done for a `GeoMakie.Axis` because the default axis for
+    # plotting is a `Makie.Axis`
+    """
+        Makie.preferred_axis_attributes(
+            ::Type{Makie.Axis},
+            var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 1}},
+        ) where {T1, T2}
+
+    Return a `NamedTuple` of the preferred axis attributes for a `OutputVar` representing
+    one-dimensional data.
+    """
+    function Makie.preferred_axis_attributes(
+        ::Type{Makie.Axis},
+        var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 1}},
+    ) where {T1, T2}
+        title = ClimaAnalysis.long_name(var)
+        xlabel = first(ClimaAnalysis.dim_names(var))
+        ylabel = ClimaAnalysis.short_name(var)
+
+        dim_units = ClimaAnalysis.dim_units(var, xlabel)
+        var_units = ClimaAnalysis.units(var)
+
+        isempty(dim_units) || (xlabel *= " ($dim_units)")
+        isempty(var_units) || (ylabel *= " ($var_units)")
+
+        return (; title, ylabel, xlabel)
+    end
+
+    """
+        Makie.preferred_axis_attributes(
+            ::Type{Makie.Axis},
+            var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 2}},
+        ) where {T1, T2}
+
+    Return a `NamedTuple` of the preferred axis attributes for a `OutputVar` representing
+    two-dimensional data.
+    """
+    function Makie.preferred_axis_attributes(
+        ::Type{Makie.Axis},
+        var::ClimaAnalysis.OutputVar{T1, <:AbstractArray{T2, 2}},
+    ) where {T1, T2}
+        if ClimaAnalysis.has_longitude(var) && ClimaAnalysis.has_latitude(var)
+            var = permutedims(var, ("lon", "lat"))
+        end
+        title = ClimaAnalysis.long_name(var)
+        dimnames = collect(ClimaAnalysis.dim_names(var))
+        xlabel = first(dimnames)
+        ylabel = last(dimnames)
+
+        var_units = ClimaAnalysis.units(var)
+        first_dim_units = ClimaAnalysis.dim_units(var, xlabel)
+        second_dim_units = ClimaAnalysis.dim_units(var, ylabel)
+
+        isempty(var_units) || (title *= " ($var_units)")
+        isempty(first_dim_units) || (xlabel *= " ($first_dim_units)")
+        isempty(second_dim_units) || (ylabel *= " ($second_dim_units)")
+
+        return (; title, xlabel, ylabel)
+    end
+end
+
 end

--- a/test/test_GeoMakieExt.jl
+++ b/test/test_GeoMakieExt.jl
@@ -6,6 +6,15 @@ import GeoMakie
 
 using OrderedCollections
 
+import ClimaAnalysis.Template:
+    TemplateVar,
+    make_template_var,
+    add_attribs,
+    add_dim,
+    add_data,
+    one_to_n_data,
+    initialize
+
 @testset "MakieExt" begin
     tmp_dir = mktempdir(cleanup = false)
     @info "Tempdir", tmp_dir
@@ -277,4 +286,35 @@ using OrderedCollections
     )
     output_name = joinpath(tmp_dir, "plot_bias_with_custom_mask.png")
     Makie.save(output_name, fig14)
+end
+
+@testset "Plot with Makie functions with GeoAxis" begin
+    tmp_dir = mktempdir(cleanup = false)
+    @info "Plots with GeoMakie", tmp_dir
+
+    lat = -90.0:1.0:90.0
+    lon = -180:1.0:180.0
+    data2d = [cos(x / 90) * sin(y / 180) for x in lat, y in lon]
+    var2d =
+        TemplateVar() |>
+        add_dim("lat", lat, units = "degrees") |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_attribs(;
+            long_name = "Hello",
+            short_name = "hi",
+            units = "W / m^2",
+        ) |>
+        add_data(; data = data2d) |>
+        initialize
+
+    fig = Makie.Figure()
+    ax1 = GeoMakie.GeoAxis(fig[1, 1], title = "Lat-lon order")
+    Makie.surface!(ax1, var2d; shading = Makie.NoShading)
+    ax2 = GeoMakie.GeoAxis(fig[1, 2], title = "Lon-lat order")
+    Makie.surface!(
+        ax2,
+        permutedims(var2d, ("lon", "lat"));
+        shading = Makie.NoShading,
+    )
+    Makie.save(joinpath(tmp_dir, "surface_plot.png"), fig)
 end

--- a/test/test_MakieExt.jl
+++ b/test/test_MakieExt.jl
@@ -5,6 +5,15 @@ import CairoMakie
 
 using OrderedCollections
 
+import ClimaAnalysis.Template:
+    TemplateVar,
+    make_template_var,
+    add_attribs,
+    add_dim,
+    add_data,
+    one_to_n_data,
+    initialize
+
 @testset "MakieExt" begin
 
     tmp_dir = mktempdir(cleanup = false)
@@ -398,4 +407,78 @@ using OrderedCollections
         model_names = ["CliMA"],
         best_category_name = "ANN",
     )
+end
+
+@testset "Plot with Makie functions" begin
+    tmp_dir = mktempdir(cleanup = false)
+    @info "Plots with Makie", tmp_dir
+
+    # Define OutputVars for plotting
+    lat = -90.0:1.0:90.0
+    lon = -180:1.0:180.0
+    time = [0.0, 1.0, 5.0, 6.0]
+    var1d =
+        TemplateVar() |>
+        add_dim("time", time, units = "s") |>
+        add_attribs(;
+            long_name = "Hello",
+            short_name = "hi",
+            units = "W / m^2",
+        ) |>
+        one_to_n_data() |>
+        initialize
+    data2d = [cos(x / 90) * sin(y / 180) for x in lat, y in lon]
+    var2d =
+        TemplateVar() |>
+        add_dim("lat", lat, units = "degrees") |>
+        add_dim("lon", lon, units = "degrees") |>
+        add_attribs(;
+            long_name = "Hello",
+            short_name = "hi",
+            units = "W / m^2",
+        ) |>
+        add_data(; data = data2d) |>
+        initialize
+
+    # Test plot
+    fig = Makie.Figure()
+    Makie.plot(fig[1, 1], var1d)
+    Makie.plot(fig[1, 2], var2d)
+    Makie.save(joinpath(tmp_dir, "12d_plot.png"), fig)
+
+    # Surface plots with lon-lat order and lat-lon order
+    fig = Makie.Figure()
+    Makie.heatmap(fig[1, 1], var2d)
+    Makie.heatmap(fig[1, 2], permutedims(var2d, ("lon", "lat")))
+    Makie.save(joinpath(tmp_dir, "heatmaps_plot.png"), fig)
+
+    # Test specific plotting functions
+    to_plot_vec = [
+        (var2d, Makie.contour),
+        (var2d, Makie.heatmap),
+        (var1d, Makie.lines),
+        (var1d, Makie.linesegments), # this doesn't work?
+        (var1d, Makie.scatter),
+        (var1d, Makie.scatterlines),
+        (var1d, Makie.stairs),
+        (var2d, Makie.surface),
+    ]
+
+    for (var, plot_fn) in to_plot_vec
+        fig = Makie.Figure()
+        plot_fn(fig[1, 1], var)
+        Makie.save(joinpath(tmp_dir, "$(plot_fn)_plot.png"), fig)
+    end
+
+    # Error handling
+    var0d =
+        TemplateVar() |>
+        add_attribs(;
+            long_name = "Hello",
+            short_name = "hi",
+            units = "W / m^2",
+        ) |>
+        one_to_n_data() |>
+        initialize
+    @test_throws ErrorException Makie.plot(var0d)
 end


### PR DESCRIPTION
This PR adds basic Makie conversions, so that `Makie.plot(var)` and `Makie.lines(var)` works out of the box.

The intention of the PR is to make it simpler to plot `OutputVar`s  for debugging or you need more customization (e.g. with plotting for calibration).

# TODO

- [x] Add tests
- [x] Add to NEWS.md
- [x] Add to docs