### PR TITLE
Refresh LICENSE, and NOTICE metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 California Institute of Technology
+   Copyright 2023-2026 California Institute of Technology (Climate Modeling Alliance)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright (c) 2023, the California Institute of Technology (Caltech)
+Copyright 2023-2026 California Institute of Technology (Climate Modeling Alliance)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Updated LICENSE and NOTICE copyright to `2023-2026 California Institute of Technology (Climate Modeling Alliance)`, using the repo's actual first-commit year.

## Test plan
- [x] Confirm README renders correctly on GitHub (badges resolve, logo displays)
- [x] Confirm all links in the README are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3GJ3g8X3sQuPCnGcrwfTy