### PR TITLE
Remove allocations

### DIFF
--- a/src/Atmos.jl
+++ b/src/Atmos.jl
@@ -23,9 +23,7 @@ Note: Values outside of the range are linearly extrapolated
 """
 function _resample_column!(dest, var1d, origin_pressure, target_pressure)
     reverse_origin_pressure = reverse(origin_pressure)
-    isunique =
-        length(unique(reverse_origin_pressure)) ==
-        length(reverse_origin_pressure)
+    isunique = allunique(reverse_origin_pressure)
     !(isunique && issorted(reverse_origin_pressure)) &&
         error("P(z) is not bijective, cannot resample column")
     # Interpolations.jl require increasing knots, but pressure is decreasing, so

--- a/src/Catalog.jl
+++ b/src/Catalog.jl
@@ -86,9 +86,9 @@ function add_file!(catalog::NCCatalog, filepaths::Vector, short_names...)
     length(filepaths) == 1 &&
         return add_file!(catalog, first(filepaths), short_names...)
 
-    all(isfile.(filepaths)) ||
+    all(isfile, filepaths) ||
         throw(ArgumentError("There is at least one non-file in $filepaths"))
-    all(endswith.(filepaths, ".nc")) || throw(
+    all(endswith(".nc"), filepaths) || throw(
         ArgumentError(
             "There is at least one file in $filepaths that is not a NetCDF file, because the file path does not end with .nc",
         ),

--- a/src/Leaderboard.jl
+++ b/src/Leaderboard.jl
@@ -68,13 +68,11 @@ function RMSEVariable(
     )
 
     # Check if RMSE is negative
-    any(RMSEs .< 0.0) && error("RMSEs cannot be negative")
+    any(<(0.0), RMSEs) && error("RMSEs cannot be negative")
 
     # Check for uniqueness
-    length(unique(model_names)) == length(model_names) ||
-        error("Model names are not unique")
-    length(unique(category_names)) == length(category_names) ||
-        error("Category names are not unique")
+    allunique(model_names) || error("Model names are not unique")
+    allunique(category_names) || error("Category names are not unique")
     model2index = OrderedDict(model_names |> enumerate |> collect .|> reverse)
     category2index =
         OrderedDict(category_names |> enumerate |> collect .|> reverse)
@@ -464,7 +462,7 @@ produced by `ClimaAnalysis.Visualize.plot_boxplot!`.
 function reorder_categories(rmse_var::RMSEVariable, categories::Vector{String})
     # Check if it is possible to reorder the categories
     rmse_var_categories = category_names(rmse_var)
-    same_categories = Set(categories) == Set(rmse_var_categories)
+    same_categories = issetequal(categories, rmse_var_categories)
     same_categories || error(
         "Categories in $(rmse_var_categories) is not the same as $categories",
     )
@@ -497,7 +495,7 @@ function match_category_order(
     rmse_var_dest_categories = category_names(rmse_var_dest)
 
     same_categories =
-        Set(rmse_var_src_categories) == Set(rmse_var_dest_categories)
+        issetequal(rmse_var_src_categories, rmse_var_dest_categories)
     same_categories || error(
         "Categories in $rmse_var_src_categories (src) is not the same as $rmse_var_dest_categories (dest)",
     )
@@ -611,9 +609,10 @@ Return nothing if units are not missing and units are the same across all models
 return an error.
 """
 function _unit_check(rmse_var::RMSEVariable)
-    units = values(rmse_var.units) |> collect
-    unit_equal = all(unit -> unit == first(units), units)
-    (!unit_equal || first(units) == "") &&
+    units = values(rmse_var.units)
+    first_unit = first(units)
+    unit_equal = all(==(first_unit), units)
+    (!unit_equal || first_unit == "") &&
         error("Units are not the same across all models or units are missing")
     return nothing
 end

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1589,7 +1589,7 @@ function Base.permutedims(var::OutputVar, perm)
     conventional_dim_name_perm = conventional_dim_name.(collect(perm))
 
     # Check if the dimensions are the same (order does not matter)
-    Set(conventional_dim_name_var) == Set(conventional_dim_name_perm) || error(
+    issetequal(conventional_dim_name_var, conventional_dim_name_perm) || error(
         "Dimensions are not the same between var ($conventional_dim_name_var) and perm ($conventional_dim_name_perm)",
     )
 
@@ -1636,7 +1636,7 @@ function reordered_as(src_var::OutputVar, dest_var::OutputVar)
     conventional_dim_name_dest = conventional_dim_name.(keys(dest_var.dims))
 
     # Check if the dimensions are the same (order does not matter)
-    Set(conventional_dim_name_src) == Set(conventional_dim_name_dest) || error(
+    issetequal(conventional_dim_name_src, conventional_dim_name_dest) || error(
         "Dimensions are not the same between src ($conventional_dim_name_src) and dest ($conventional_dim_name_dest)",
     )
 

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -1615,8 +1615,7 @@ function Base.permutedims(var::OutputVar, perm)
     end
     merge!(ret_dim_attribs, var_dim_attribs)
 
-    ret_data = copy(var.data)
-    ret_data = permutedims(ret_data, reorder_indices)
+    ret_data = permutedims(var.data, reorder_indices)
     return remake(
         var,
         dims = ret_dims,

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -243,7 +243,7 @@ end
 function OutputVar(attribs, dims, dim_attribs, data)
     index2dim = keys(dims) |> collect
     dim2index =
-        Dict([dim_name => index for (index, dim_name) in enumerate(keys(dims))])
+        Dict(dim_name => index for (index, dim_name) in enumerate(keys(dims)))
 
     # Check if the size of data matches with the size of dims
     if !(
@@ -812,7 +812,7 @@ import Statistics: mean
 long = 0.:180. |> collect
 lat = 0.:90. |> collect
 data = reshape(1.:91*181., (181, 91))
-dims = Dict(["lat" => lat, "long" => long])
+dims = Dict("lat" => lat, "long" => long)
 var = OutputVar(dims, data)
 _reduce_over(mean, "lat", var)
 ```

--- a/src/flat.jl
+++ b/src/flat.jl
@@ -254,10 +254,10 @@ function unflatten(metadata::Metadata, data::AbstractVector)
     unflattened_data = reshape(flat_data, reshape_dims...)
 
     # Permute dimensions of data
-    dim2index = Dict([
+    dim2index = Dict(
         dim_name => index for
         (index, dim_name) in enumerate(keys(metadata.dims))
-    ])
+    )
     perm = invperm(
         collect(dim2index[dim_name] for dim_name in metadata.ordered_dims),
     )

--- a/src/flat.jl
+++ b/src/flat.jl
@@ -267,7 +267,7 @@ function unflatten(metadata::Metadata, data::AbstractVector)
         deepcopy(metadata.attributes),
         deepcopy(metadata.dims),
         deepcopy(metadata.dim_attributes),
-        copy(data),
+        data,
     )
 end
 

--- a/src/masks.jl
+++ b/src/masks.jl
@@ -33,12 +33,12 @@ const LANDSEA_MASK = let
         lon, lat, data
     end
 
-    dims = OrderedDict(["lon" => lon, "lat" => lat])
+    dims = OrderedDict("lon" => lon, "lat" => lat)
     attribs = Dict("long_name" => "Land sea mask")
-    dim_attribs = OrderedDict([
+    dim_attribs = OrderedDict(
         "lat" => Dict("units" => "deg"),
         "lon" => Dict("units" => "deg"),
-    ])
+    )
     var = OutputVar(attribs, dims, dim_attribs, data)
 end
 


### PR DESCRIPTION
I asked Claude to find any easy fixes to allocations. The changes are not materializing vectors when constructing dictionaries, using more idiomatic functions like `issetequal`, and removing unnecessary copying.