### PR TITLE
Add interpolation module

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,22 @@ Makie.surface(fig[1, 1], var)
 Makie.save("surface_plot.png", fig)
 ```
 
+## New regridder
+
+Interpolating and resampling no longer use `Interpolations.jl`. Instead,
+`ClimaAnalysis` now comes with its own regridder to improve the performance of
+`Var.resampled_as`.
+
+There are two user-visible changes:
+
+1. Interpolating or resampling outside of the domain of a dimension now throws a
+   `DomainError` instead of a `BoundsError`.
+2. For Interpolations.jl, the element type of the destination data depends on
+   the element types of the source coordinates, the source data, and the
+   destination coordinates. With the new regridder, the element type of the
+   destination data depends on the element types of the source coordinates and
+   the source data.
+
 ## Minor additions
 
 - The number of dimensions of a `OutputVar` can be accessed with `ndims`.

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -139,7 +139,7 @@ A multilinear interpolation is used to determine the value at the coordinate (0,
 
 !!! warning "Interpolate on dates"
     If any of the dimensions contains `Dates.DateTime` elements, interpolation is not
-    possible. `Interpolations.jl` does not support interpolating on dates.
+    possible, because interpolating on dates is not supported.
 
 Extrapolating is supported only on the longitude and latitude dimensions. For the longitude
 and latitude dimensions, a periodic boundary condition and a flat boundary condition are

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -146,16 +146,16 @@ function Regridder(
 
     for (dim_idx, coords) in enumerate(src_grid)
         length(coords) >= 2 || error(
-            "The $(dim_idx)th dimension has less than two coordinates, which is not supported",
+            "Dimension $dim_idx has less than two coordinates, which is not supported",
         )
 
         # NaN and missing values in coordinates are not supported
         any(x -> ismissing(x) || isnan(x), coords) && error(
-            "Missing or NaN values for the $(dim_idx)th dimension is not supported",
+            "Missing or NaN values for dimension $dim_idx is not supported",
         )
 
         issorted(coords, lt = <=) ||
-            error("The $(dim_idx)th dimension  is not strictly increasing")
+            error("Dimension $dim_idx is not strictly increasing")
     end
 
     for (dim_idx, (coords, extp)) in enumerate(zip(src_grid, extrapolation))

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -1,0 +1,582 @@
+module Interpolation
+
+import OrderedCollections: OrderedDict
+
+"""
+    Node
+
+A staggering where the coordinates are the edges of the cells, so the first
+and last coordinates are the boundaries of the domain.
+"""
+struct Node end
+
+"""
+    Center
+
+A staggering where the coordinates are the centers of the cells, so the domain
+extends half a cell beyond the first and last coordinates.
+"""
+struct Center end
+
+"""
+    AbstractExtrapolation
+
+An object that determines how values outside of the domain are handled when
+interpolating.
+"""
+abstract type AbstractExtrapolation end
+
+"""
+    Throw
+
+A boundary condition where an error is thrown if it is outside of the domain.
+"""
+struct Throw <: AbstractExtrapolation end
+
+"""
+    Flat
+
+A boundary condition where values outside of the domain evaluate to the value
+at the nearest boundary point.
+"""
+struct Flat <: AbstractExtrapolation end
+
+"""
+    Periodic
+
+A boundary condition where the domain repeats with a physical period of
+`period`, so values outside of the domain are wrapped back into it.
+"""
+struct Periodic{FT} <: AbstractExtrapolation
+    period::FT
+end
+
+"""
+    AbstractInterpolationMethod
+
+An object that determines the interpolation method of the regridder.
+"""
+abstract type AbstractInterpolationMethod end
+
+"""
+    LinearInterpolation
+
+Linear interpolation, where NaNs propagate through the weighted sum.
+"""
+struct LinearInterpolation <: AbstractInterpolationMethod end
+
+"""
+    Regridder
+
+Linearly interpolate gridded data with support for node and centers and throw,
+flat, and periodic boundary conditions.
+"""
+struct Regridder{
+    N,
+    A <: AbstractArray,
+    SG <: NTuple{N, AbstractVector},
+    E <: NTuple{N, AbstractExtrapolation},
+    S <: NTuple{N, Union{Node, Center}},
+    M <: AbstractInterpolationMethod,
+}
+
+    "Source data to interpolate from"
+    src_data::A
+
+    "Coordinates of the source data"
+    src_grid::SG
+
+    "Extrapolation conditions for how queries outside the source coordinates are
+    handled"
+    extrapolation::E
+
+    "Whether the coordinates of each dimension are cell centers (`Center`) or
+    cell edges (`Node`)."
+    staggering::S
+
+    "Interpolation method (`LinearInterpolation`)"
+    method::M
+end
+
+"""
+    Regridder(
+        src_data::AbstractArray,
+        src_grid,
+        extrapolation,
+        staggering;
+        method = LinearInterpolation(),
+    )
+
+Construct a `Regridder` object from `src_data`, `src_grid`, `extrapolation`,
+and `staggering`, interpolating with `method`.
+
+The argument `src_grid` is a tuple of strictly increasing coordinate vectors,
+one per dimension of `src_data`. The argument `extrapolation` is an iterable of
+`AbstractExtrapolation` (e.g. `(Periodic(360.0), Flat())`) and `staggering` an
+iterable of `Node` or `Center`, one entry per dimension.
+
+The number of dimensions of `src_data` and `src_grid` and the length of
+`extrapolation` and `staggering` must all be the same.
+"""
+function Regridder(
+    src_data::AbstractArray,
+    src_grid,
+    extrapolation,
+    staggering;
+    method::AbstractInterpolationMethod = LinearInterpolation(),
+)
+    extrapolation = Tuple(extrapolation)
+    staggering = Tuple(staggering)
+
+    num_src_dims = ndims(src_data)
+
+    # Check dimensions match
+    length(extrapolation) == num_src_dims || error(
+        "Number of extrapolation conditions is not the same as the number of dimensions of the source data",
+    )
+    length(staggering) == num_src_dims || error(
+        "Number of staggering is not the same as the number of dimensions of the source data",
+    )
+    length(src_grid) == num_src_dims || error(
+        "Number of dimensions in src_grid is not the same as the number of dimensions of the source data",
+    )
+    map(length, src_grid) == size(src_data) || error(
+        "Lengths of dimensions in src_grid ($(map(length, src_grid))) do not match size(src_data) ($(size(src_data)))",
+    )
+
+    for (dim_idx, coords) in enumerate(src_grid)
+        length(coords) >= 2 || error(
+            "The $(dim_idx)th dimension has less than two coordinates, which is not supported",
+        )
+
+        # NaN and missing values in coordinates are not supported
+        any(x -> ismissing(x) || isnan(x), coords) && error(
+            "Missing or NaN values for the $(dim_idx)th dimension is not supported",
+        )
+
+        issorted(coords, lt = <=) ||
+            error("The $(dim_idx)th dimension  is not strictly increasing")
+    end
+
+    for (dim_idx, (coords, extp)) in enumerate(zip(src_grid, extrapolation))
+        # Check the periodic boundary condition if it exists for each dimension
+        extp isa Periodic || continue
+        extp.period > 0 || error(
+            "Period of dimension $dim_idx ($(extp.period)) is not positive",
+        )
+        span = coords[end] - coords[begin]
+        (span <= extp.period || span ≈ extp.period) || error(
+            "Span of dimension $dim_idx ($span) is larger than the period ($(extp.period))",
+        )
+    end
+
+    return Regridder(src_data, src_grid, extrapolation, staggering, method)
+end
+
+"""
+    regrid(regridder::Regridder, dest_grid::OrderedDict)
+
+Regrid the data in `regridder` to match `dest_grid`.
+"""
+function regrid(regridder::Regridder, dest_grid::OrderedDict)
+    return regrid(regridder, Tuple(values(dest_grid)))
+end
+
+"""
+    regrid!(dest_data, regridder::Regridder, dest_grid::OrderedDict)
+
+Regrid `dest_data` in-place using `regridder` to match `dest_grid`.
+"""
+function regrid!(
+    dest_data::AbstractArray,
+    regridder::Regridder,
+    dest_grid::OrderedDict,
+)
+    return regrid!(dest_data, regridder, Tuple(values(dest_grid)))
+end
+
+"""
+    regrid(regridder::Regridder, dest_grid::Tuple)
+
+Regrid the data in `regridder` to match `dest_grid`.
+"""
+function regrid(regridder::Regridder, dest_grid::Tuple)
+    dest_data = Array{_dest_eltype(regridder)}(undef, map(length, dest_grid))
+    regrid!(dest_data, regridder, dest_grid)
+    return dest_data
+end
+
+"""
+    regrid!(
+        dest_data,
+        regridder::Regridder{N},
+        dest_grid::Tuple,
+    ) where {N}
+
+Regrid `dest_data` in-place using `regridder` to match `dest_grid`.
+"""
+function regrid!(
+    dest_data::AbstractArray,
+    regridder::Regridder{N},
+    dest_grid::Tuple,
+) where {N}
+    length(dest_grid) == N || throw(
+        ArgumentError(
+            "Destination grid has $(length(dest_grid)) dimensions, but the regridder has $N dimensions for the source grid",
+        ),
+    )
+    size(dest_data) == map(length, dest_grid) || throw(
+        DimensionMismatch(
+            "The number of dimensions of the destination data $(size(dest_data)) does not match the dimension sizes of destination grid ($(map(length, dest_grid)))",
+        ),
+    )
+
+    # Create empty cache for storing results of stencil computation
+    # The cache are preallocated per-dimension buffers of 1D stencils
+    # `(index1, index2, weight)`, one per destination coordinate
+    # The weight type is promoted from the element types of the destination
+    # grid, so the precision of the destination coordinates is not lost when
+    # computing the weights
+    FT = float(
+        promote_type(
+            _src_eltype(regridder),
+            map(nonmissingtype ∘ eltype, dest_grid)...,
+        ),
+    )
+    stencil_cache = ntuple(_ -> Tuple{Int, Int, FT}[], Val(N))
+
+    # Precompute the cache for each dimension
+    for (dim_idx, (src_coords, dest_coords)) in
+        enumerate(zip(regridder.src_grid, dest_grid))
+        _fill_dim_cache!(
+            stencil_cache[dim_idx],
+            dest_coords,
+            src_coords,
+            regridder.extrapolation[dim_idx],
+            regridder.staggering[dim_idx],
+        )
+    end
+
+    (; src_data, method) = regridder
+    @inbounds for J in CartesianIndices(dest_data)
+        stencils = ntuple(d -> stencil_cache[d][J[d]], Val(N))
+        dest_data[J] = _apply_stencils(FT, src_data, stencils, method)
+    end
+    return nothing
+end
+
+"""
+    _fill_dim_cache!(
+        cache::Vector{Tuple{Int, Int, FT}},
+        dest_coords::AbstractVector,
+        src_coords::AbstractVector,
+        extrapolation::AbstractExtrapolation,
+        staggering::Union{Node, Center},
+    )
+
+Fill out the stencil `cache` for a single dimension.
+
+Each destination coordinate is converted to the weight type `FT`, so the
+stencil weights are computed at the precision of `FT`.
+"""
+function _fill_dim_cache!(
+    cache::Vector{Tuple{Int, Int, FT}},
+    dest_coords::AbstractVector,
+    src_coords::AbstractVector,
+    extrapolation::AbstractExtrapolation,
+    staggering::Union{Node, Center},
+) where {FT}
+    resize!(cache, length(dest_coords))
+    for (j, x) in enumerate(dest_coords)
+        cache[j] = _stencil_1d(FT(x), src_coords, extrapolation, staggering)
+    end
+    return cache
+end
+
+"""
+    _apply_stencils(
+        ::Type{T},
+        src_data::AbstractArray,
+        stencils,
+        method::AbstractInterpolationMethod,
+    ) where {T}
+
+Compute a single value for linear interpolation for a single point using the
+`stencils` and `src_data`.
+"""
+@inline function _apply_stencils(
+    ::Type{T},
+    src_data::AbstractArray,
+    stencils,
+    ::LinearInterpolation,
+) where {T}
+    N = length(stencils)
+    # Iterate over all 2^N corners and compute a weighted average
+    corners = CartesianIndices(ntuple(_ -> 2, Val(N)))
+    acc = zero(T)
+    @inbounds for corner in corners
+        idx = ntuple(
+            d -> corner[d] == 1 ? stencils[d][1] : stencils[d][2],
+            Val(N),
+        )
+        w = one(stencils[1][3])
+        for d in 1:N
+            w *= corner[d] == 1 ? stencils[d][3] : one(w) - stencils[d][3]
+        end
+        v = src_data[idx...]
+        # A missing value propagates through the weighted sum
+        ismissing(v) && return missing
+        acc += w * v
+    end
+    # This is needed for the interpolate and interpolate! to return the same
+    # type as regrid and regrid!
+    return T(acc)
+end
+
+# All stencil functions return (index1, index2, w) where w is the weight used to
+# compute val = w * data[index1] + (1 - w) * data[index2]
+
+"""
+    _stencil_1d(
+        x::Number,
+        coords::AbstractVector,
+        extrapolation::AbstractExtrapolation,
+        staggering::Union{Node, Center},
+    )
+
+Compute the stencil `(index1, index2, w)` given `x` and `coords` with
+`extrapolation` and `staggering`.
+"""
+function _stencil_1d(
+    x::Number,
+    coords::AbstractVector,
+    extrapolation::AbstractExtrapolation,
+    staggering::Union{Node, Center},
+)
+    FT = float(promote_type(typeof(x), nonmissingtype(eltype(coords))))
+    (i1, i2, w) = if _in_interior(x, coords)
+        _interior_stencil(x, coords)
+    else
+        _boundary_stencil(x, coords, extrapolation, staggering)
+    end
+    return (i1, i2, FT(w))
+end
+
+"""
+    _in_interior(x::Number, coords::AbstractVector)
+
+Return whether `x` is in the domain of `coords`.
+"""
+@inline function _in_interior(x::Number, coords::AbstractVector)
+    first_coord = coords[begin]
+    last_coord = coords[end]
+    return first_coord <= x <= last_coord
+end
+
+"""
+    _interior_stencil(x::Number, coords::AbstractVector)
+
+Return the stencil `(index1, index2, w)` for `x` and `coords` when `x` is in
+the domain of `coords`.
+"""
+@inline function _interior_stencil(x::Number, coords::AbstractVector)
+    i = searchsortedfirst(coords, x)
+    first_index = firstindex(coords)
+    (i1, i2) = i != first_index ? (i - 1, i) : (first_index, first_index + 1)
+    w = (coords[i2] - x) / (coords[i2] - coords[i1])
+    return (i1, i2, w)
+end
+
+"""
+    _boundary_stencil(
+        x::Number,
+        coords::AbstractVector,
+        ::Throw,
+        ::Node,
+)
+
+Throw an error when `x` is outside of `coords`.
+"""
+@inline function _boundary_stencil(
+    x::Number,
+    coords::AbstractVector,
+    ::Throw,
+    ::Node,
+)
+    first_coord = coords[begin]
+    last_coord = coords[end]
+    return throw(
+        DomainError(
+            x,
+            "Cannot interpolate because $x is not in the domain [$first_coord, $last_coord]",
+        ),
+    )
+end
+
+"""
+    _boundary_stencil(
+        x::Number,
+        coords::AbstractVector,
+        ::Throw,
+        ::Center,
+)
+
+Return the stencil `(index1, index2, w)` for `x` and `coords` when `x` is within
+half a cell of the first or last coordinate and throw an error otherwise.
+
+The stencil linearly extends the two nearest coordinates, so the weight is
+outside of `[0, 1]` there.
+"""
+@inline function _boundary_stencil(
+    x::Number,
+    coords::AbstractVector,
+    ::Throw,
+    ::Center,
+)
+    left = firstindex(coords)
+    right = lastindex(coords)
+    half_width_left = (coords[left + 1] - coords[left]) / 2
+    half_width_right = (coords[right] - coords[right - 1]) / 2
+    in_left_cell = coords[left] - half_width_left <= x < coords[left]
+    if in_left_cell
+        w = (coords[left + 1] - x) / (coords[left + 1] - coords[left])
+        return (left, left + 1, w)
+    end
+    in_right_cell = coords[right] < x <= coords[right] + half_width_right
+    if in_right_cell
+        w = (coords[right] - x) / (coords[right] - coords[right - 1])
+        return (right - 1, right, w)
+    end
+    throw(
+        DomainError(
+            x,
+            "x is outside the domain [$(coords[left] - half_width_left), $(coords[right] + half_width_right)]",
+        ),
+    )
+end
+
+"""
+    _boundary_stencil(
+        x::Number,
+        coords::AbstractVector,
+        ::Flat,
+        ::Union{Center, Node},
+    )
+
+Return the stencil `(index1, index2, w)` for `x` and `coords` which compute the
+same value at the leftmost or rightmost center or node.
+
+For `Center`, the value is constant everywhere outside the first and last
+coordinates, including within half a cell of them.
+"""
+@inline function _boundary_stencil(
+    x::Number,
+    coords::AbstractVector,
+    ::Flat,
+    ::Union{Center, Node},
+)
+    left = firstindex(coords)
+    right = lastindex(coords)
+    FT = float(nonmissingtype(eltype(coords)))
+    # NaN compares false with <
+    isnan(x) && return (left, left, FT(NaN))
+    w = one(FT)
+    return x < coords[left] ? (left, left, w) : (right, right, w)
+end
+
+"""
+    _boundary_stencil(
+        x::Number,
+        coords::AbstractVector,
+        extrapolation::Periodic,
+        ::Union{Center, Node},
+    )
+
+Return the stencil `(index1, index2, w)` for `x` and `coords` which accounts
+for `coords` being `Periodic`.
+"""
+@inline function _boundary_stencil(
+    x::Number,
+    coords::AbstractVector,
+    extrapolation::Periodic,
+    ::Union{Center, Node},
+)
+    (; period) = extrapolation
+    left = firstindex(coords)
+    right = lastindex(coords)
+    x_wrapped = coords[left] + mod(x - coords[left], period)
+    if x_wrapped <= coords[right]
+        return _interior_stencil(x_wrapped, coords)
+    else
+        # x_wrapped is in the wrap gap (coords[end], coords[begin] + period),
+        # so interpolate between the last and first points
+        wrap_coord = coords[left] + period
+        w = (wrap_coord - x_wrapped) / (wrap_coord - coords[right])
+        return (right, left, w)
+    end
+end
+
+"""
+    interpolate(
+        regridder::Regridder{N},
+        point::Tuple{Vararg{Number, N}},
+    ) where {N}
+
+Interpolate a single `point` using the `regridder`.
+"""
+function interpolate(
+    regridder::Regridder{N},
+    point::Tuple{Vararg{Number, N}},
+) where {N}
+    FT = _src_eltype(regridder)
+    # Since it is a single point, we do not need to cache the results
+    stencils = map(
+        (x, coords, extp, stag) -> begin
+            (i1, i2, w) = _stencil_1d(x, coords, extp, stag)
+            (i1, i2, FT(w))
+        end,
+        point,
+        regridder.src_grid,
+        regridder.extrapolation,
+        regridder.staggering,
+    )
+    return _apply_stencils(FT, regridder.src_data, stencils, regridder.method)
+end
+
+"""
+    interpolate(regridder::Regridder, points::AbstractArray)
+
+Interpolate multiple `points` using the `regridder`.
+"""
+function interpolate(regridder::Regridder, points::AbstractArray)
+    return map(point -> interpolate(regridder, point), points)
+end
+
+"""
+    _src_eltype(regridder::Regridder)
+
+Return the float type promoted from the element types of the source data and
+source grid of `regridder`, excluding `Missing`.
+"""
+function _src_eltype(regridder::Regridder)
+    return float(
+        promote_type(
+            nonmissingtype(eltype(regridder.src_data)),
+            map(nonmissingtype ∘ eltype, regridder.src_grid)...,
+        ),
+    )
+end
+
+"""
+    _dest_eltype(regridder::Regridder)
+
+Return the eltype of the data produced by `regridder`.
+"""
+function _dest_eltype(regridder::Regridder)
+    return promote_type(
+        _src_eltype(regridder),
+        float(eltype(regridder.src_data)),
+    )
+end
+
+end

--- a/src/Numerics.jl
+++ b/src/Numerics.jl
@@ -3,6 +3,8 @@ module Numerics
 import ..Utils: _isequispaced
 import NaNStatistics: nansum
 
+include("Interpolation.jl")
+
 """
     _integrate_lon(data::AbstractArray, lon::AbstractVector; dims)
 

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -4,12 +4,12 @@ import Dates
 import NCDatasets
 import OrderedCollections: OrderedDict
 
-import Interpolations as Intp
 import Statistics
 import Statistics: mean
 import NaNStatistics: nanmean, nanvar
 
 import ..Numerics
+import ..Numerics: Interpolation
 import ..Utils:
     nearest_index,
     seconds_to_prettystr,
@@ -118,104 +118,65 @@ include("flat.jl")
 const HasDimAndAttribs = Union{OutputVar, FlatVar, Metadata}
 
 """
-    _make_interpolant(dims, data)
+    _make_regridder(dims, data)
 
-Make a linear interpolant from `dims`, a dictionary mapping dimension name to array and
-`data`, an array containing data. Used in constructing a `OutputVar`.
+Make a `Interpolation.Regridder` from `dims`, a dictionary mapping dimension name to array
+and `data`, an array containing data.
 
-If any element of the arrays in `dims` is a Dates.DateTime, then no interpolant is returned.
-Interpolations.jl does not support interpolating on dates. If the longitudes span the entire
-range and are equispaced, then a periodic boundary condition is added for the longitude
-dimension. If the latitudes span the entire range and are equispaced, then a flat boundary
-condition is added for the latitude dimension. In all other cases, an error is thrown when
-extrapolating outside of `dim_array`.
+If any element of the arrays in `dims` is a Dates.DateTime, then no regridder is returned,
+because regridding on dates is not supported. If the longitudes span the entire range and
+are equispaced, then a periodic boundary condition is added for the longitude dimension. If
+the latitudes span the entire range and are equispaced, then a flat boundary condition is
+added for the latitude dimension. In all other cases, an error is thrown when extrapolating
+outside of `dim_array`.
 """
-function _make_interpolant(dims, data)
-    # If any element is DateTime, then return nothing for the interpolant because
-    # Interpolations.jl do not support DateTimes
+function _make_regridder(dims, data)
+    # If any element is DateTime, then return nothing for the regridder because
+    # regridding on dates is not supported
     for dim_array in values(dims)
         eltype(dim_array) <: Dates.DateTime && return nothing
     end
 
-    # We can only create interpolants when we have 1D dimensions
+    # We can only create regridders when we have 1D dimensions with more than
+    # one coordinate
     if isempty(dims) || any(d -> ndims(d) != 1 || length(d) == 1, values(dims))
         return nothing
     end
 
-    # Dimensions are all 1D, check that the knots are in increasing order (as required by
-    # Interpolations.jl)
+    # Check that the coordinates are in increasing order
     for (dim_name, dim_array) in dims
-        if !issorted(dim_array)
-            @warn "Dimension $dim_name is not in increasing order. An interpolant will not be created. See Var.reverse_dim and Var.reverse_dim! if the dimension is in decreasing order"
+        if !issorted(dim_array, lt = <=)
+            @warn "Dimension $dim_name is not in increasing order. A regridder will not be created. See Var.reverse_dim and Var.reverse_dim! if the dimension is in decreasing order"
             return nothing
         end
     end
 
-    # Find boundary conditions for extrapolation
-    extp_bound_conds = (
-        _find_extp_bound_cond(dim_name, dim_array) for
+    # Find extrapolation condition and staggering for each dimension
+    extp_and_stag = [
+        _find_extp_and_staggering(dim_name, dim_array) for
         (dim_name, dim_array) in dims
-    )
+    ]
 
-    dims_tuple, data = _add_extra_lon_point(dims, data)
-
-    extp_bound_conds_tuple = tuple(extp_bound_conds...)
-    return Intp.extrapolate(
-        Intp.interpolate(dims_tuple, data, Intp.Gridded(Intp.Linear())),
-        extp_bound_conds_tuple,
+    return Interpolation.Regridder(
+        data,
+        Tuple(values(dims)),
+        Tuple(first.(extp_and_stag)),
+        Tuple(last.(extp_and_stag)),
     )
 end
 
 """
-    _add_extra_lon_point(dims, data)
+    _find_extp_and_staggering(dim_name, dim_array)
 
-Helper function for adding a extra longitude point when making an interpolant.
+Find the appropriate extrapolation condition and staggering for the `dim_name` dimension.
 
-An extra longitude point is added if the points of the longitude dimension represent centers
-instead of edges of the cells and the longitude dimension spans all 360 degrees.
-
-For example, if the longitude dimension is [0.5, 1.5, ..., 359.5] or [0.0, 1.0, ..., 359.0],
-then an extra longitude point will be added to the interpolant.
+Longitudes that are equispaced cell centers spanning all 360 degrees get a periodic boundary
+condition with the physical period of 360 degrees. Longitudes whose span is exactly 360
+degrees are nodes with a duplicated endpoint and also get a periodic boundary condition.
+Latitudes that are equispaced cell centers spanning all 180 degrees get a flat boundary
+condition. In all other cases, an error is thrown when extrapolating outside of `dim_array`.
 """
-function _add_extra_lon_point(dims, data)
-    # Do not want to add an extra point to the dimensions of the OutputVar
-    dims_tuple = tuple(deepcopy(values(dims))...)
-
-    for (idx, (dim_name, dim_array)) in enumerate(dims)
-        min_of_dim, max_of_dim = extrema(dim_array)
-        dim_size = max_of_dim - min_of_dim
-        dsize = dim_array[begin + 1] - dim_array[begin]
-        if conventional_dim_name(dim_name) == "longitude" &&
-           _isequispaced(dim_array) &&
-           isapprox(dim_size + dsize, 360.0)
-            lon = dims_tuple[idx]
-
-            # Append extra lon point
-            # For example, if the longitude dimension is [0.5, 1.5, ..., 359.5], then add
-            # 360.5. If the value of 360 is evaluated, it should be the average of the
-            # points at 0.5 and 359.5 which is what we compute by adding the extra longitude
-            # point and using ongrid.
-            push!(lon, lon[end] + dsize)
-
-            # Add corresponding lon slice to the end of data along the index
-            # corresponding to the longitude dimension
-            first_lon_slice = selectdim(data, idx, 1)
-            data = stack(
-                (eachslice(data, dims = idx)..., first_lon_slice),
-                dims = idx,
-            )
-        end
-    end
-
-    return (dims_tuple, data)
-end
-
-"""
-    _find_extp_bound_cond(dim_name, dim_array)
-
-Find the appropriate boundary condition for the `dim_name` dimension.
-"""
-function _find_extp_bound_cond(dim_name, dim_array)
+function _find_extp_and_staggering(dim_name, dim_array)
     min_of_dim, max_of_dim = extrema(dim_array)
     dim_size = max_of_dim - min_of_dim
     dsize = dim_array[begin + 1] - dim_array[begin]
@@ -227,17 +188,17 @@ function _find_extp_bound_cond(dim_name, dim_array)
         conventional_dim_name(dim_name) == "longitude" &&
         _isequispaced(dim_array) &&
         isapprox(dim_size + dsize, 360.0)
-    ) && return Intp.Periodic()
+    ) && return (Interpolation.Periodic(360.0), Interpolation.Center())
     (
         conventional_dim_name(dim_name) == "longitude" &&
         (dim_array[end] - dim_array[begin]) ≈ 360.0
-    ) && return Intp.Periodic()
+    ) && return (Interpolation.Periodic(360.0), Interpolation.Node())
     (
         conventional_dim_name(dim_name) == "latitude" &&
         _isequispaced(dim_array) &&
         isapprox(dim_size + dsize, 180.0)
-    ) && return Intp.Flat()
-    return Intp.Throw()
+    ) && return (Interpolation.Flat(), Interpolation.Center())
+    return (Interpolation.Throw(), Interpolation.Node())
 end
 
 function OutputVar(attribs, dims, dim_attribs, data)
@@ -1421,10 +1382,10 @@ end
 Interpolate variable `x` onto the given `target_coord` coordinate using
 multilinear interpolation.
 
-Extrapolation is now allowed and will throw a `BoundsError` in most cases.
+Extrapolation is not allowed and will throw a `DomainError` in most cases.
 
 If any element of the arrays of the dimensions is a Dates.DateTime, then interpolation is
-not possible. Interpolations.jl do not support making interpolations for dates. If the
+not possible, because interpolating on dates is not supported. If the
 longitudes span the entire range and are equispaced, then a periodic boundary condition is
 added for the longitude dimension. If the latitudes span the entire range and are
 equispaced, then a flat boundary condition is added for the latitude dimension. In all other
@@ -1448,8 +1409,8 @@ julia> var2d = ClimaAnalysis.OutputVar(Dict("time" => time, "z" => z), data); va
 ```
 """
 function (x::OutputVar)(target_coord)
-    itp = _make_interpolant(x.dims, x.data)
-    return itp(target_coord...)
+    regridder = _make_regridder(x.dims, x.data)
+    return Interpolation.interpolate(regridder, Tuple(target_coord))
 end
 
 """
@@ -1717,9 +1678,9 @@ function _resampled_as_all(src_var::OutputVar, dest_var::OutputVar)
         src_var = reordered_as(src_var, dest_var)
     end
 
-    itp = _make_interpolant(src_var.dims, src_var.data)
+    regridder = _make_regridder(src_var.dims, src_var.data)
     src_resampled_data =
-        [itp(pt...) for pt in Base.product(values(dest_var.dims)...)]
+        Interpolation.regrid(regridder, Tuple(values(dest_var.dims)))
 
     # Make new dimensions for OutputVar
     src_var_ret_dims = empty(src_var.dims)
@@ -1765,9 +1726,9 @@ function _resampled_as_partial(
         end
     end
 
-    itp = _make_interpolant(src_var.dims, src_var.data)
+    regridder = _make_regridder(src_var.dims, src_var.data)
     src_resampled_data =
-        [itp(pt...) for pt in Base.product(values(src_var_ret_dims)...)]
+        Interpolation.regrid(regridder, Tuple(values(src_var_ret_dims)))
 
     return remake(src_var, dims = src_var_ret_dims, data = src_resampled_data)
 end

--- a/src/masks.jl
+++ b/src/masks.jl
@@ -305,14 +305,15 @@ function make_lonlat_mask(
 
         # Resample so that the mask match up with the grid of var
         # Round because linear resampling is done and we want the mask to be only ones and zeros
-        intp = _make_interpolant(mask_var.dims, mask_var.data)
+        regridder = _make_regridder(mask_var.dims, mask_var.data)
         mask_arr =
-            [
-                intp(pt...) for pt in Base.product(
+            Interpolation.regrid(
+                regridder,
+                (
                     input_var.dims[longitude_name(input_var)],
                     input_var.dims[latitude_name(input_var)],
-                )
-            ] .|> round
+                ),
+            ) .|> round
 
         # Reshape data for broadcasting
         lon_idx = input_var.dim2index[longitude_name(input_var)]

--- a/test/test_Numerics.jl
+++ b/test/test_Numerics.jl
@@ -1,5 +1,7 @@
 using Test
 import ClimaAnalysis
+import ClimaAnalysis.Numerics.Interpolation as Intp
+import OrderedCollections: OrderedDict
 
 @testset "integration weights for lon and lat" begin
     # Integration weights for lon (not equispaced)
@@ -164,4 +166,391 @@ end
         ClimaAnalysis.Numerics._integrate_dim(z_data, z, dims = 1)[1],
         2.5,
     )
+end
+
+@testset "Regridder construction" begin
+    data = reshape(1.0:9.0, (3, 3))
+    grid = ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    extp = (Intp.Throw(), Intp.Flat())
+    stag = (Intp.Node(), Intp.Center())
+
+    regridder = Intp.Regridder(data, grid, extp, stag)
+    @test regridder.src_grid == grid
+    @test regridder.src_data == data
+    @test regridder.extrapolation == extp
+    @test regridder.staggering == stag
+    @test regridder.method == Intp.LinearInterpolation()
+
+    # Extrapolation and staggering can be any iterable
+    regridder = Intp.Regridder(
+        data,
+        grid,
+        [Intp.Throw(), Intp.Flat()],
+        [Intp.Node(), Intp.Center()],
+    )
+    @test regridder.extrapolation == extp
+    @test regridder.staggering == stag
+
+    # Number of dimensions of everything must match
+    @test_throws "Number of extrapolation conditions" Intp.Regridder(
+        data,
+        grid,
+        (Intp.Throw(),),
+        stag,
+    )
+    @test_throws "Number of staggering" Intp.Regridder(
+        data,
+        grid,
+        extp,
+        (Intp.Node(),),
+    )
+    @test_throws "Number of dimensions in src_grid" Intp.Regridder(
+        data,
+        (grid[1],),
+        extp,
+        stag,
+    )
+    @test_throws "do not match size(src_data)" Intp.Regridder(
+        data,
+        ([1.0, 2.0], [4.0, 5.0, 6.0]),
+        extp,
+        stag,
+    )
+
+    # Coordinates must be strictly increasing with at least two coordinates
+    @test_throws "less than two coordinates" Intp.Regridder(
+        ones(3, 1),
+        ([1.0, 2.0, 3.0], [4.0]),
+        extp,
+        stag,
+    )
+    @test_throws "not strictly increasing" Intp.Regridder(
+        data,
+        ([1.0, 1.0, 2.0], [4.0, 5.0, 6.0]),
+        extp,
+        stag,
+    )
+    @test_throws "not strictly increasing" Intp.Regridder(
+        data,
+        ([3.0, 2.0, 1.0], [4.0, 5.0, 6.0]),
+        extp,
+        stag,
+    )
+
+    # Period must be positive and not smaller than the span of the coordinates
+    @test_throws "is not positive" Intp.Regridder(
+        data,
+        grid,
+        (Intp.Periodic(-360.0), Intp.Flat()),
+        stag,
+    )
+    @test_throws "larger than the period" Intp.Regridder(
+        data,
+        grid,
+        (Intp.Periodic(1.5), Intp.Flat()),
+        stag,
+    )
+
+    # Longitudes whose span slightly exceeds 360 degrees should still get a
+    # periodic boundary condition
+    noisy_lon = [0.0, 90.0, 180.0, 270.0, 360.0 + 1.0e-6]
+    noisy = Intp.Regridder(
+        [1.0, 2.0, 3.0, 4.0, 1.0],
+        (noisy_lon,),
+        (Intp.Periodic(360.0),),
+        (Intp.Node(),),
+    )
+    # mod(405, 360) is 45
+    @test Intp.interpolate(noisy, (405.0,)) ≈ 1.5
+end
+
+@testset "Interpolating a point or a vector of points" begin
+    # 1D
+    coords = ([1.0, 2.0, 3.0],)
+    data = [3.0, 1.0, 0.0]
+
+    throw_node = Intp.Regridder(data, coords, (Intp.Throw(),), (Intp.Node(),))
+    @test Intp.interpolate(throw_node, (1.0,)) == 3.0
+    @test Intp.interpolate(throw_node, (3.0,)) == 0.0
+    @test Intp.interpolate(throw_node, (1.5,)) == 2.0
+    @test Intp.interpolate(throw_node, [(1.0,), (1.5,), (2.5,)]) ==
+          [3.0, 2.0, 0.5]
+    @test_throws DomainError Intp.interpolate(throw_node, (0.0,))
+    @test_throws DomainError Intp.interpolate(throw_node, (4.0,))
+
+    # Values outside of the domain evaluate to the value at the boundary
+    flat_node = Intp.Regridder(data, coords, (Intp.Flat(),), (Intp.Node(),))
+    @test Intp.interpolate(flat_node, (0.0,)) == 3.0
+    @test Intp.interpolate(flat_node, (4.0,)) == 0.0
+    @test Intp.interpolate(flat_node, (1.5,)) == 2.0
+    @test isnan(Intp.interpolate(flat_node, (NaN,)))
+
+    # With Center staggering, the domain extends half a cell beyond the first
+    # and last coordinates and values in the margins are linearly extended
+    throw_center =
+        Intp.Regridder(data, coords, (Intp.Throw(),), (Intp.Center(),))
+    @test Intp.interpolate(throw_center, (0.75,)) == 3.5
+    @test Intp.interpolate(throw_center, (3.25,)) == -0.25
+    @test_throws DomainError Intp.interpolate(throw_center, (0.25,))
+    @test_throws DomainError Intp.interpolate(throw_center, (3.75,))
+
+    # 2D
+    coords = ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    data = reshape(1.0:9.0, (3, 3))
+    throw2d = Intp.Regridder(
+        data,
+        coords,
+        (Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(throw2d, (1.0, 4.0)) == 1.0
+    @test Intp.interpolate(throw2d, (3.0, 6.0)) == 9.0
+    @test Intp.interpolate(throw2d, (2.0, 5.0)) == 5.0
+    @test Intp.interpolate(throw2d, (1.5, 4.5)) == 3.0
+    @test Intp.interpolate(throw2d, (1.5, 5.5)) == 6.0
+
+    # Extrapolation conditions apply per dimension
+    flat_throw = Intp.Regridder(
+        data,
+        coords,
+        (Intp.Flat(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test_throws DomainError Intp.interpolate(flat_throw, (0.0, 8.0))
+    @test Intp.interpolate(flat_throw, (0.0, 5.5)) == 5.5
+
+    flat_flat = Intp.Regridder(
+        data,
+        coords,
+        (Intp.Flat(), Intp.Flat()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(flat_flat, (0.0, 8.0)) == 7.0
+
+    # 3D
+    coords = ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0])
+    data = reshape(1.0:27.0, (3, 3, 3))
+    throw3d = Intp.Regridder(
+        data,
+        coords,
+        (Intp.Throw(), Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(throw3d, (1.0, 5.0, 7.0)) == 4.0
+    @test Intp.interpolate(throw3d, (1.5, 5.2, 7.5)) ≈ 9.6
+
+    # Non equispaced coordinates
+    coords = ([1.0, 3.0, 7.0], [4.0, 5.0, 7.0])
+    data = reshape(1.0:9.0, (3, 3))
+    noneq = Intp.Regridder(
+        data,
+        coords,
+        (Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(noneq, (2.0, 4.5)) == 3.0
+    @test Intp.interpolate(noneq, (5.0, 6.0)) == 7.0
+end
+
+@testset "Periodic boundary condition" begin
+    # Note that the data at the endpoints do not agree
+    lon = [0.0, 90.0, 180.0, 270.0, 360.0]
+    data = [1.0, 2.0, 3.0, 4.0, 10.0]
+    node = Intp.Regridder(data, (lon,), (Intp.Periodic(360.0),), (Intp.Node(),))
+    @test Intp.interpolate(node, (0.0,)) == 1.0
+    @test Intp.interpolate(node, (360.0,)) == 10.0
+    @test Intp.interpolate(node, (720.0,)) == 1.0
+    @test Intp.interpolate(node, (45.0,)) == 1.5
+    @test Intp.interpolate(node, (405.0,)) == 1.5
+    @test Intp.interpolate(node, (-45.0,)) == 7.0
+    @test Intp.interpolate(node, (-90.0,)) == 4.0
+
+    # Center staggering without a duplicated endpoint; points between the
+    # last and first coordinates interpolate across the wrap
+    lon = [45.0, 135.0, 225.0, 315.0]
+    data = [1.0, 2.0, 3.0, 4.0]
+    center =
+        Intp.Regridder(data, (lon,), (Intp.Periodic(360.0),), (Intp.Center(),))
+    @test Intp.interpolate(center, (45.0,)) == 1.0
+    # The points 0.0 and 360.0 represents the same location
+    @test Intp.interpolate(center, (0.0,)) == 2.5
+    @test Intp.interpolate(center, (360.0,)) == 2.5
+    @test Intp.interpolate(center, (337.5,)) == 3.25
+    @test Intp.interpolate(center, (405.0,)) == 1.0
+end
+
+@testset "Regridding" begin
+    src_grid = ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    data = reshape(1.0:9.0, (3, 3))
+    regridder = Intp.Regridder(
+        data,
+        src_grid,
+        (Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+
+    # Regridding onto the same grid reproduces the data
+    @test Intp.regrid(regridder, src_grid) == data
+
+    # Regridding agrees with interpolating each point
+    dest_grid = ([1.0, 1.5, 2.0, 2.5, 3.0], [4.0, 4.5, 5.0])
+    expected = [
+        Intp.interpolate(regridder, (x, y)) for
+        x in dest_grid[1], y in dest_grid[2]
+    ]
+    @test Intp.regrid(regridder, dest_grid) == expected
+
+    # The same regridder can be reused with a different destination grid
+    another_dest_grid = ([1.5, 2.5], [4.5, 5.5])
+    another_expected = [
+        Intp.interpolate(regridder, (x, y)) for
+        x in another_dest_grid[1], y in another_dest_grid[2]
+    ]
+    @test Intp.regrid(regridder, another_dest_grid) == another_expected
+
+    # In-place regridding
+    dest_data = zeros(5, 3)
+    Intp.regrid!(dest_data, regridder, dest_grid)
+    @test dest_data == expected
+
+    # OrderedDict adapters
+    dest_dict = OrderedDict("lon" => dest_grid[1], "lat" => dest_grid[2])
+    @test Intp.regrid(regridder, dest_dict) == expected
+    fill!(dest_data, 0.0)
+    Intp.regrid!(dest_data, regridder, dest_dict)
+    @test dest_data == expected
+
+    # Check size and dimensions
+    @test_throws DimensionMismatch Intp.regrid!(
+        zeros(2, 2),
+        regridder,
+        dest_grid,
+    )
+    @test_throws ArgumentError Intp.regrid!(
+        zeros(5),
+        regridder,
+        (dest_grid[1],),
+    )
+
+    # Test with points in no particular order
+    @test Intp.regrid(regridder, ([3.0, 1.0, 2.0], [4.5, 4.5])) ==
+          [4.5 4.5; 2.5 2.5; 3.5 3.5]
+
+    # Empty destination grids
+    @test size(Intp.regrid(regridder, (Float64[], [4.0]))) == (0, 1)
+    @test size(Intp.regrid(regridder, (Float64[], Float64[]))) == (0, 0)
+
+    # A point has to have as many coordinates as the regridder has dimensions
+    @test_throws MethodError Intp.interpolate(regridder, (1.0,))
+    @test_throws MethodError Intp.interpolate(regridder, (1.0, 4.0, 7.0))
+end
+
+@testset "Interpolating and regridding agree" begin
+    # Interpolation happens in the promotion of the float types of the source
+    # data and source grid, so regrid! gives the same values as regrid and
+    # interpolate assuming that the destination array is the same type
+    src_data = Float32[1.0, 1.0000001, 2.0]
+    regridder = Intp.Regridder(
+        src_data,
+        ([1.0, 2.0, 3.0],),
+        (Intp.Flat(),),
+        (Intp.Node(),),
+    )
+
+    intp_val = Intp.interpolate(regridder, (1.5,))
+    regridded_val = Intp.regrid(regridder, ([1.5],))[1]
+    @test intp_val isa Float64
+    @test regridded_val isa Float64
+    @test intp_val == regridded_val
+
+    dest64 = zeros(1)
+    Intp.regrid!(dest64, regridder, ([1.5],))
+    @test dest64[1] == intp_val
+
+    dest32 = zeros(Float32, 1)
+    Intp.regrid!(dest32, regridder, ([1.5],))
+    @test dest32[1] == Float32(intp_val)
+end
+
+@testset "Regridding with different types" begin
+    # Coordinates and points with different float types
+    data = [1.0 3.0; 2.0 4.0]
+    regridder = Intp.Regridder(
+        data,
+        ([1.0f0, 2.0f0], Float16[3.0, 4.0]),
+        (Intp.Flat(), Intp.Flat()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(regridder, (1.5f0, 3.5)) == 2.5
+    @test Intp.interpolate(regridder, (1.5, 4.5f0)) == 3.5
+
+    # Mixed float types for coordinates and source data lead to the right float
+    # type for destination data
+    regridder_mixed = Intp.Regridder(
+        Float32[1.0, 2.0, 4.0],
+        ([1.0f0, 2.0f0, 3.0f0],),
+        (Intp.Flat(),),
+        (Intp.Node(),),
+    )
+    @test Intp.interpolate(regridder_mixed, (2.5,)) === 3.0f0
+    @test eltype(Intp.regrid(regridder_mixed, ([2.5],))) == Float32
+
+    # The eltype of the destination data is the promotion of the eltypes of the
+    # source grid and the source data
+    regridder_promote = Intp.Regridder(
+        Float32[1.0, 2.0, 4.0],
+        ([1.0, 2.0, 3.0],),
+        (Intp.Flat(),),
+        (Intp.Node(),),
+    )
+    @test Intp.interpolate(regridder_promote, (2.5,)) === 3.0
+    @test eltype(Intp.regrid(regridder_promote, ([2.5],))) == Float64
+
+    # Integer source data produces floating point destination data
+    regridder_int = Intp.Regridder(
+        reshape(1:9, (3, 3)),
+        ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]),
+        (Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(regridder_int, (2.0, 5.0)) === 5.0
+    out = Intp.regrid(regridder_int, ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0]))
+    @test eltype(out) == Float64
+    @test out == reshape(1:9, (3, 3))
+
+    # Element type of destination data is Union{Missing, T} if element type of
+    # source data is Union{Missing, T} too
+    lon_m = convert(Vector{Union{Missing, Float64}}, [1.0, 2.0, 3.0])
+    data_m = convert(
+        Matrix{Union{Missing, Float64}},
+        collect(reshape(1.0:9.0, (3, 3))),
+    )
+    regridder_m = Intp.Regridder(
+        data_m,
+        (lon_m, [4.0, 5.0, 6.0]),
+        (Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+    @test Intp.interpolate(regridder_m, (1.5, 4.5)) === 3.0
+    out = Intp.regrid(regridder_m, (lon_m, [4.0, 4.5, 5.0]))
+    @test eltype(out) == Union{Missing, Float64}
+    @test out == [1.0 2.5 4.0; 2.0 3.5 5.0; 3.0 4.5 6.0]
+
+    # Actual missing values propagate through interpolation and regridding
+    data_missing =
+        convert(Vector{Union{Missing, Float64}}, [10.0, 20.0, 30.0, 40.0])
+    data_missing[3] = missing
+    regridder_missing = Intp.Regridder(
+        data_missing,
+        ([1.0, 2.0, 3.0, 4.0],),
+        (Intp.Throw(),),
+        (Intp.Node(),),
+    )
+    @test Intp.interpolate(regridder_missing, (1.5,)) == 15.0
+    @test ismissing(Intp.interpolate(regridder_missing, (2.5,)))
+    out = Intp.regrid(regridder_missing, ([1.5, 2.5, 3.5],))
+    @test eltype(out) == Union{Missing, Float64}
+    @test out[1] == 15.0
+    @test ismissing(out[2])
+    @test ismissing(out[3])
 end

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -2,7 +2,7 @@ using Test
 import ClimaAnalysis
 
 import Statistics
-import Interpolations as Intp
+import ClimaAnalysis.Numerics.Interpolation as Intp
 import NaNStatistics: nanmean, nansum, nanvar
 import NCDatasets: NCDataset
 import OrderedCollections: OrderedDict
@@ -221,8 +221,10 @@ end
     time = 1.0:100 |> collect
     data = ones(length(lon), length(lat), length(time))
     dims = OrderedDict(["lon" => lon, "lat" => lat, "time" => time])
-    intp = ClimaAnalysis.Var._make_interpolant(dims, data)
-    @test intp.et == (Intp.Periodic(), Intp.Flat(), Intp.Throw())
+    regridder = ClimaAnalysis.Var._make_regridder(dims, data)
+    @test regridder.extrapolation ==
+          (Intp.Periodic(360.0), Intp.Flat(), Intp.Throw())
+    @test regridder.staggering == (Intp.Center(), Intp.Center(), Intp.Node())
 
     # Not equispaced for lon and lat
     lon = 0.5:1.0:359.5 |> collect |> x -> push!(x, 42.0) |> sort
@@ -230,8 +232,8 @@ end
     time = 1.0:100 |> collect
     data = ones(length(lon), length(lat), length(time))
     dims = OrderedDict(["lon" => lon, "lat" => lat, "time" => time])
-    intp = ClimaAnalysis.Var._make_interpolant(dims, data)
-    @test intp.et == (Intp.Throw(), Intp.Throw(), Intp.Throw())
+    regridder = ClimaAnalysis.Var._make_regridder(dims, data)
+    @test regridder.extrapolation == (Intp.Throw(), Intp.Throw(), Intp.Throw())
 
     # Does not span entire range for and lat
     lon = 0.5:1.0:350.5 |> collect
@@ -239,15 +241,16 @@ end
     time = 1.0:100 |> collect
     data = ones(length(lon), length(lat), length(time))
     dims = OrderedDict(["lon" => lon, "lat" => lat, "time" => time])
-    intp = ClimaAnalysis.Var._make_interpolant(dims, data)
-    @test intp.et == (Intp.Throw(), Intp.Throw(), Intp.Throw())
+    regridder = ClimaAnalysis.Var._make_regridder(dims, data)
+    @test regridder.extrapolation == (Intp.Throw(), Intp.Throw(), Intp.Throw())
 
     # Lon is exactly 360 degrees
     lon = 0.0:1.0:360.0 |> collect
     data = ones(length(lon))
     dims = OrderedDict(["lon" => lon])
-    intp = ClimaAnalysis.Var._make_interpolant(dims, data)
-    @test intp.et == (Intp.Periodic(),)
+    regridder = ClimaAnalysis.Var._make_regridder(dims, data)
+    @test regridder.extrapolation == (Intp.Periodic(360.0),)
+    @test regridder.staggering == (Intp.Node(),)
 
     # Dates for the time dimension
     lon = 0.5:1.0:359.5 |> collect
@@ -259,15 +262,24 @@ end
     ]
     data = ones(length(lon), length(lat), length(time))
     dims = OrderedDict(["lon" => lon, "lat" => lat, "time" => time])
-    intp = ClimaAnalysis.Var._make_interpolant(dims, data)
-    @test isnothing(intp)
+    regridder = ClimaAnalysis.Var._make_regridder(dims, data)
+    @test isnothing(regridder)
 
     # 2D dimensions
     arb_dim = reshape(collect(range(-89.5, 89.5, 16)), (4, 4))
     data = collect(1:16)
     dims = OrderedDict(["arb_dim" => arb_dim])
-    intp = ClimaAnalysis.Var._make_interpolant(dims, data)
-    @test isnothing(intp)
+    regridder = ClimaAnalysis.Var._make_regridder(dims, data)
+    @test isnothing(regridder)
+
+    # Longitudes whose span slightly exceeds 360 degrees should still get a
+    # periodic boundary condition
+    lon = collect(range(0.0, 360.0, length = 361))
+    lon[end] += 1.0e-6
+    dims = OrderedDict(["lon" => lon])
+    regridder = ClimaAnalysis.Var._make_regridder(dims, ones(length(lon)))
+    @test regridder.extrapolation == (Intp.Periodic(360.0),)
+    @test regridder.staggering == (Intp.Node(),)
 end
 
 @testset "empty" begin
@@ -1188,7 +1200,7 @@ end
     @test longvar.([10.5, 20.5]) == [10.5, 20.5]
 
     # Test error for data outside of range
-    @test_throws BoundsError longvar(200.0)
+    @test_throws DomainError longvar(200.0)
 
     # 2D interpolation with linear data, should yield correct results
     time = 100.0:110.0 |> collect
@@ -1782,7 +1794,7 @@ end
     @test src_var.data == ClimaAnalysis.resampled_as(src_var, src_var).data
     resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var)
     @test resampled_var.data == reshape(1.0:(181 * 91), (181, 91))[1:91, 1:46]
-    @test_throws BoundsError ClimaAnalysis.resampled_as(dest_var, src_var)
+    @test_throws DomainError ClimaAnalysis.resampled_as(dest_var, src_var)
 
     # Test if reordering is automatically done
     src_var_transpose = permutedims(src_var, ("latitude", "longitude"))
@@ -1793,13 +1805,13 @@ end
     resampled_var =
         ClimaAnalysis.resampled_as(src_var, long = dest_long, lat = dest_lat)
     @test resampled_var.data == reshape(1.0:(181 * 91), (181, 91))[1:91, 1:46]
-    @test_throws BoundsError ClimaAnalysis.resampled_as(
+    @test_throws DomainError ClimaAnalysis.resampled_as(
         dest_var,
         long = src_long,
         lat = src_lat,
     )
 
-    # BoundsError check
+    # DomainError check
     src_long = 90.0:120.0 |> collect
     src_lat = 45.0:90.0 |> collect
     src_data = zeros(length(src_long), length(src_lat))
@@ -1813,13 +1825,63 @@ end
     dest_var =
         ClimaAnalysis.remake(dest_var, data = dest_data, dims = dest_dims)
 
-    @test_throws BoundsError ClimaAnalysis.resampled_as(src_var, dest_var)
+    @test_throws DomainError ClimaAnalysis.resampled_as(src_var, dest_var)
 
     # Error handling with ordered iterable for dims
     @test_throws ErrorException ClimaAnalysis.resampled_as(
         src_var,
         pfull = [1.0, 2.0],
     )
+end
+
+@testset "Resampling with different types" begin
+    src_long = 0.0:180.0 |> collect
+    src_lat = 0.0:90.0 |> collect
+    src_template =
+        TemplateVar() |>
+        add_dim("long", src_long, units = "deg") |>
+        add_dim("lat", src_lat, units = "deg")
+
+    dest_var =
+        TemplateVar() |>
+        add_dim("long", 0.0:2.0:90.0 |> collect, units = "deg") |>
+        add_dim("lat", 0.0:2.0:45.0 |> collect, units = "deg") |>
+        ones_data() |>
+        initialize
+
+    # The eltype of the resampled data is the promotion of the eltypes of the
+    # data and the dims of the OutputVar being resampled
+    var64 = src_template |> ones_data() |> initialize
+    @test eltype(ClimaAnalysis.resampled_as(var64, dest_var).data) == Float64
+
+    var32 = src_template |> ones_data(data_type = Float32) |> initialize
+    @test eltype(ClimaAnalysis.resampled_as(var32, dest_var).data) == Float64
+
+    var_all32 =
+        TemplateVar() |>
+        add_dim("long", Float32.(src_long), units = "deg") |>
+        add_dim("lat", Float32.(src_lat), units = "deg") |>
+        ones_data(data_type = Float32) |>
+        initialize
+    @test eltype(ClimaAnalysis.resampled_as(var_all32, dest_var).data) ==
+          Float32
+
+    var_allows_missing =
+        src_template |>
+        ones_data(data_type = Union{Missing, Float64}) |>
+        initialize
+    @test eltype(
+        ClimaAnalysis.resampled_as(var_allows_missing, dest_var).data,
+    ) == Union{Missing, Float64}
+
+    # Missing values propagate and Missing is kept in the eltype
+    data_missing =
+        ones(Union{Missing, Float64}, length(src_long), length(src_lat))
+    data_missing[5, 5] = missing
+    var_missing = src_template |> add_data(data = data_missing) |> initialize
+    resampled_missing = ClimaAnalysis.resampled_as(var_missing, dest_var)
+    @test eltype(resampled_missing.data) == Union{Missing, Float64}
+    @test any(ismissing, resampled_missing.data)
 end
 
 @testset "Resampling ongrid and oncenter" begin
@@ -2006,7 +2068,7 @@ end
         add_dim("long", dest_long, units = "test_units1") |>
         add_attribs(long_name = "hi") |>
         initialize
-    @test_throws BoundsError ClimaAnalysis.resampled_as(
+    @test_throws DomainError ClimaAnalysis.resampled_as(
         src_var,
         dest_var,
         dim_names = "longitude",
@@ -3832,7 +3894,7 @@ end
         add_attribs(long_name = "hi") |>
         add_data(data = data) |>
         initialize
-    @test isnothing(ClimaAnalysis.Var._make_interpolant(var.dims, data))
+    @test isnothing(ClimaAnalysis.Var._make_regridder(var.dims, data))
 
     # Test reverse_dim
     reverse_var = ClimaAnalysis.reverse_dim(var, "lat")


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaAnalysis.jl/issues/182 - This PR adds the module Interpolation which implements its own regridder for linear interpolation on CPU. This speeds up `resampled_as` as shown in the benchmark below. This is also needed to implement `NaN`-aware interpolation which will build on top of this PR. 

```
# ClimaCoupler leaderboard plots comparsion using @time
# Current release of ClimaAnalysis
# First call
633.497110 seconds (4.78 G allocations: 350.271 GiB, 11.06% gc time, 25.36% compilation time: 11% of which was recompilation)

# Second call
453.559515 seconds (4.48 G allocations: 336.167 GiB, 9.66% gc time, 0.05% compilation time: 37% of which was recompilation)

# This branch
# First call
226.008800 seconds (326.68 M allocations: 142.870 GiB, 11.99% gc time, 52.08% compilation time: 15% of which was recompilation)

# Second call
95.502202 seconds (47.26 M allocations: 129.401 GiB, 16.47% gc time, 0.24% compilation time: 37% of which was recompilation)
```