### PR TITLE
Exclude NaNs from normalization in error metrics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,11 @@ Makie.save("surface_plot.png", fig)
 - Masks generated from `generate_lonlat_mask` are now recognized as masking
   functions when plotting (e.g. `plot_bias_on_globe!`). Previously, they were
   not recognized, so plotting proceeded without applying the mask.
+- `bias` and `squared_error` (and thus `global_bias`, `global_mse`, and
+  `global_rmse`) now exclude NaNs from the normalization, so results are
+  correct when the data contains NaNs, whether or not a mask is passed.
+- `Atmos.global_rmse_pfull` also excludes NaNs from the normalizations and
+  warns when the observational data contains NaNs.
 - Enforce uniqueness when splitting dates by seasons across time.
 - Exclude NaNStatistics v0.6.57 in compat, because of correctness issues and
   possibility of a segfault. See this

--- a/src/Atmos.jl
+++ b/src/Atmos.jl
@@ -183,6 +183,8 @@ function global_rmse_pfull(
 
     # Follow the same template for squared_error
     Var._check_sim_obs_units_consistent(sim, obs, 3)
+    any(isnan, obs.data) &&
+        @warn "NaNs detected in observational data, resampling is not NaN aware"
     obs_resampled = Var.resampled_as(obs, sim)
 
     squared_error = (sim - obs_resampled) * (sim - obs_resampled)
@@ -190,11 +192,12 @@ function global_rmse_pfull(
     # Compute global mse and global rmse and store it as an attribute
     integrated_squared_error_var = Var.integrate_lonlat(squared_error)
     integrated_squared_error = integrated_squared_error_var.data
+    # NaNs are skipped when integrating, so exclude them from the normalizations too
     ones_var = OutputVar(
         squared_error.attributes,
         squared_error.dims,
         squared_error.dim_attributes,
-        ones(size(squared_error.data)),
+        map(x -> isnan(x) ? x : one(x), squared_error.data),
     )
     normalization = Var.integrate_lonlat(ones_var).data
     # Doing ./ because both quantities are vectors
@@ -202,8 +205,13 @@ function global_rmse_pfull(
 
     pfull = Var.pressures(integrated_squared_error_var)
     # Use first because the return type is an array
-    length_pfull =
-        first(Numerics._integrate_dim(ones(size(pfull)), pfull; dims = 1))
+    length_pfull = first(
+        Numerics._integrate_dim(
+            map(x -> isnan(x) ? x : one(x), mse),
+            pfull;
+            dims = 1,
+        ),
+    )
 
     # Normalize and compute RMSE
     # Use first because the return type is an array

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -2286,10 +2286,11 @@ This function is currently implemented for `OutputVar`s with only the dimensions
 and latitude. Units must be supplied for data and dimensions in `sim` and `obs`. The units
 for longitude and latitude should be degrees. Resampling is done automatically by resampling
 `obs` on `sim`. Attributes in `sim` and `obs` will be thrown away. The long name and short
-name of the returned `OutputVar` will be updated to reflect that a bias is computed.
+name of the returned `OutputVar` will be updated to reflect that a bias is computed. If
+`mask` is provided, the data of the returned `OutputVar` is masked as well.
 
-The parameter `mask` is a function that masks a `OutputVar`. See [`apply_landmask`](@ref)
-and [`apply_oceanmask`](@ref).
+The parameter `mask` is a function that masks a `OutputVar` and must set masked values to
+NaN or zero. See [`apply_landmask`](@ref) and [`apply_oceanmask`](@ref).
 
 See also [`global_bias`](@ref), [`squared_error`](@ref), [`global_mse`](@ref),
 [`global_rmse`](@ref).
@@ -2323,12 +2324,15 @@ function bias(sim::OutputVar, obs::OutputVar; mask = nothing)
     # Compute global bias and store it as an attribute
     !isnothing(mask) && (bias = mask(bias))
     integrated_bias = integrate_lonlat(bias).data
+    # NaNs are skipped when integrating, so exclude them from the normalization too
     ones_var = OutputVar(
         bias.attributes,
         bias.dims,
         bias.dim_attributes,
-        ones(size(bias.data)),
+        map(x -> isnan(x) ? x : one(x), bias.data),
     )
+    # Masking ones_var keeps the normalization consistent for masks that zero out data
+    # instead of NaNing them
     !isnothing(mask) && (ones_var = mask(ones_var))
     normalization = integrate_lonlat(ones_var).data
     # Do ./ instead of / because we are dividing between zero dimensional arrays
@@ -2347,8 +2351,8 @@ longitude and latitude. Units must be supplied for data and dimensions in `sim` 
 The units for longitude and latitude should be degrees. Resampling is done automatically by
 resampling `obs` on `sim`.
 
-The parameter `mask` is a function that masks a `OutputVar`. See [`apply_landmask`](@ref)
-and [`apply_oceanmask`](@ref).
+The parameter `mask` is a function that masks a `OutputVar` and must set masked values to
+NaN or zero. See [`apply_landmask`](@ref) and [`apply_oceanmask`](@ref).
 
 See also [`bias`](@ref), [`squared_error`](@ref), [`global_mse`](@ref),
 [`global_rmse`](@ref).
@@ -2370,10 +2374,11 @@ This function is currently implemented for `OutputVar`s with only the dimensions
 and latitude. Units must be supplied for data and dimensions in `sim` and `obs`. The units
 for longitude and latitude should be degrees. Resampling is done automatically by resampling
 `obs` on `sim`. Attributes in `sim` and `obs` will be thrown away. The long name and short
-name of the returned `OutputVar` will be updated to reflect that a squared error is computed.
+name of the returned `OutputVar` will be updated to reflect that a squared error is
+computed. If `mask` is provided, the data of the returned `OutputVar` is masked as well.
 
-The parameter `mask` is a function that masks a `OutputVar`. See [`apply_landmask`](@ref)
-and [`apply_oceanmask`](@ref).
+The parameter `mask` is a function that masks a `OutputVar` and must set masked values to
+NaN or zero. See [`apply_landmask`](@ref) and [`apply_oceanmask`](@ref).
 
 See also [`global_mse`](@ref), [`global_rmse`](@ref), [`bias`](@ref), [`global_bias`](@ref).
 """
@@ -2409,12 +2414,15 @@ function squared_error(sim::OutputVar, obs::OutputVar; mask = nothing)
     # Compute global mse and global rmse and store it as an attribute
     !isnothing(mask) && (squared_error = mask(squared_error))
     integrated_squared_error = integrate_lonlat(squared_error).data
+    # NaNs are skipped when integrating, so exclude them from the normalization too
     ones_var = OutputVar(
         squared_error.attributes,
         squared_error.dims,
         squared_error.dim_attributes,
-        ones(size(squared_error.data)),
+        map(x -> isnan(x) ? x : one(x), squared_error.data),
     )
+    # Masking ones_var keeps the normalization consistent for masks that zero out data
+    # instead of NaNing them
     !isnothing(mask) && (ones_var = mask(ones_var))
     normalization = integrate_lonlat(ones_var).data
     # Do ./ instead of / because we are dividing between zero dimensional arrays
@@ -2440,8 +2448,8 @@ and latitude. Units must be supplied for data and dimensions in `sim` and `obs`.
 for longitude and latitude should be degrees. Resampling is done automatically by resampling
 `obs` on `sim`.
 
-The parameter `mask` is a function that masks a `OutputVar`. See [`apply_landmask`](@ref)
-and [`apply_oceanmask`](@ref).
+The parameter `mask` is a function that masks a `OutputVar` and must set masked values to
+NaN or zero. See [`apply_landmask`](@ref) and [`apply_oceanmask`](@ref).
 
 See also [`squared_error`](@ref), [`global_rmse`](@ref), [`bias`](@ref), [`global_bias`](@ref).
 """
@@ -2461,8 +2469,8 @@ and latitude. Units must be supplied for data and dimensions in `sim` and `obs`.
 for longitude and latitude should be degrees. Resampling is done automatically by resampling
 `obs` on `sim`.
 
-The parameter `mask` is a function that masks a `OutputVar`. See [`apply_landmask`](@ref)
-and [`apply_oceanmask`](@ref).
+The parameter `mask` is a function that masks a `OutputVar` and must set masked values to
+NaN or zero. See [`apply_landmask`](@ref) and [`apply_oceanmask`](@ref).
 
 See also [`squared_error`](@ref), [`global_mse`](@ref), [`bias`](@ref), [`global_bias`](@ref).
 """

--- a/test/test_Atmos.jl
+++ b/test/test_Atmos.jl
@@ -280,6 +280,33 @@ end
     )
     @test global_rmse_pfull ≈ global_rmse_test
 
+    # NaNs are excluded from both the integral and the normalization
+    pfull_dims = OrderedDict(["lon" => lon, "lat" => lat, "pfull" => zzz])
+    pfull_dim_attribs = OrderedDict([
+        "lon" => Dict("units" => "degrees_east"),
+        "lat" => Dict("units" => "degrees_north"),
+        "pfull" => Dict("units" => "kg m^-2 s^-2"),
+    ])
+    nan_data = 2.0 .* ones(length(lon), length(lat), length(zzz))
+    nan_data[:, 1:90, :] .= NaN
+    nan_var = ClimaAnalysis.OutputVar(
+        attribs,
+        pfull_dims,
+        pfull_dim_attribs,
+        nan_data,
+    )
+    zero_pfull_var = ClimaAnalysis.remake(
+        nan_var;
+        data = zeros(length(lon), length(lat), length(zzz)),
+    )
+    @test ClimaAnalysis.Atmos.global_rmse_pfull(nan_var, zero_pfull_var) ≈ 2.0
+
+    # Test warning is thrown about NaNs in observational data
+    @test_logs (:warn, r"NaNs detected in observational data") ClimaAnalysis.Atmos.global_rmse_pfull(
+        zero_pfull_var,
+        nan_var,
+    )
+
     # Test with data from era5; checking if we get no error
     ncpath = joinpath(@__DIR__, "sample_nc/test_pfull.nc")
     pfull_obs_var = ClimaAnalysis.OutputVar(ncpath, "t")

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -2680,6 +2680,15 @@ end
     @test global_bias == 1.0
     @test bias_var.data == ones(length(lon), length(lat)) * 1.0
 
+    # NaNs are excluded from both the integral and the normalization
+    data_nan = copy(data_twos)
+    data_nan[:, 1:90] .= NaN
+    var_nan = ClimaAnalysis.remake(var_twos, data = data_nan)
+    @test ClimaAnalysis.global_bias(var_nan, var_ones) ≈ 1.0
+
+    var_all_nan = ClimaAnalysis.remake(var_ones, data = fill(NaN, 360, 180))
+    @test isnan(ClimaAnalysis.global_bias(var_all_nan, var_ones))
+
     # Test warning is thrown about NaNs
     nan_data = [[0.0, 0.0] [NaN, 0.0]]
     nan_var =
@@ -2735,6 +2744,13 @@ end
     @test global_mse == (3.0 - 1.0)^2
     @test global_rmse == 2.0
     @test squared_error_var.data == (data_threes - data_ones) .^ 2
+
+    # NaNs are excluded from both the integral and the normalization
+    data_nan = copy(data_threes)
+    data_nan[:, 1:90] .= NaN
+    var_nan = ClimaAnalysis.remake(var_threes, data = data_nan)
+    @test ClimaAnalysis.global_mse(var_nan, var_ones) ≈ 4.0
+    @test ClimaAnalysis.global_rmse(var_nan, var_ones) ≈ 2.0
 
     # Check unit handling
     lon = collect(range(-179.5, 179.5, 36))
@@ -3351,6 +3367,16 @@ end
         0.0,
         atol = 1e-5,
     )
+
+    # NaNs not covered by the mask do not skew the normalization
+    data_nan = ones(length(lon), length(lat))
+    data_nan[:, lat .< 0.0] .= NaN
+    nan_var = ClimaAnalysis.remake(zero_var, data = data_nan)
+    @test ClimaAnalysis.global_bias(
+        nan_var,
+        zero_var,
+        mask = ClimaAnalysis.apply_landmask,
+    ) ≈ 1.0
 
     # Test squared error, global_mse, and global_rmse
     # Trim data because periodic boundary condition on the edges


### PR DESCRIPTION
fixes #424 - This bug was found in https://github.com/CliMA/ClimaLand.jl/pull/1836. For `OutputVar`s with `NaN`s in the data, the error metrics could have been computed wrong if a mask function is not given. This is because the normalization is computed using the mask function. This PR fixes that issue by computing the normalization from the `NaN`s in `sim - obs`.

I asked a LLM to implement these changes.