### PR TITLE
Add abs as a unary operation for OutputVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@ Makie.save("surface_plot.png", fig)
   the time dimension (e.g. `resampled_as(var, time = [Dates.DateTime(2010)])`).
   Both `Dates.DateTime` and `Dates.Date` are supported.
 - Add `arecompatible` for `FlatVar` and `Metadata`.
+- `abs` is now defined for `OutputVar`.
 
 ## Bug fixes
 

--- a/src/outvar_operators.jl
+++ b/src/outvar_operators.jl
@@ -174,10 +174,11 @@ Generate a method to overload the unary operator `op` for `OutputVar`.
 Handles the attributes `short_name`, `long_name`, `start_date`, and `units` and prepends the
 operator name, e.g., "log(Temperature)".
 
-The attribute `units` is only kept for unary minus.
+The attribute `units` is only kept for operators that preserve units (unary minus and
+`abs`).
 """
 macro overload_unary_op(op)
-    keep_attrs = op == :(-) ? ("start_date", "units") : ("start_date",)
+    keep_attrs = op in (:(-), :abs) ? ("start_date", "units") : ("start_date",)
     esc(
         quote
             function Base.$op(x::OutputVar)
@@ -227,4 +228,5 @@ end
 @overload_unary_op cos
 @overload_unary_op tan
 @overload_unary_op sqrt
+@overload_unary_op abs
 @overload_unary_op (-) # Unary minus

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -524,6 +524,19 @@ end
         @test ClimaAnalysis.short_name(sqrt_var4) == "sqrt(bob)"
         @test ClimaAnalysis.long_name(sqrt_var4) == "sqrt(hi)"
 
+        # Absolute value (abs)
+        abs_var4 = abs(-var4)
+        @test abs_var4.data == abs.(-(var4.data))
+        @test ClimaAnalysis.short_name(abs_var4) == "abs(-(bob))"
+        @test ClimaAnalysis.long_name(abs_var4) == "abs(-(hi))"
+        @test abs_var4.attributes == Dict(
+            "short_name" => "abs(-(bob))",
+            "long_name" => "abs(-(hi))",
+            "start_date" => "2008",
+            "units" => "m^2",
+        )
+        @test abs_var4.dims == var4.dims
+
         # Unary Minus (-)
         neg_var4 = -var4
         @test neg_var4.data == -(var4.data)


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaAnalysis.jl/issues/423 - This PR adds `abs` as another unary function for `OutputVar`.