### PR TITLE
Release v0.5.23

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@ ClimaAnalysis.jl Release Notes
 main
 -------
 
+v0.5.23
+-------
+
 ## Split-apply-combine
 
 This release features an initial implemention of the split-combine-apply
@@ -66,6 +69,7 @@ There are two user-visible changes:
   Both `Dates.DateTime` and `Dates.Date` are supported.
 - Add `arecompatible` for `FlatVar` and `Metadata`.
 - `abs` is now defined for `OutputVar`.
+- The compat entry for OrderedCollections is expanded to include v2.
 
 ## Bug fixes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaAnalysis"
 uuid = "29b5916a-a76c-4e73-9657-3c8fd22e65e6"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
-version = "0.5.22"
+version = "0.5.23"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
This PR makes a release of ClimaAnalysis v0.5.23. This is needed to merge https://github.com/CliMA/ClimaCalibrate.jl/pull/334 and make a new release of ClimaCalibrate.

This should be merged after https://github.com/CliMA/ClimaAnalysis.jl/pull/418.