### PR TITLE
Add NaN-aware resampling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,23 @@ ClimaAnalysis.jl Release Notes
 main
 -------
 
+## NaN-aware resampling
+
+The `resampled_as` functions now accept the keyword argument `nan_threshold`
+to control how `NaN`s in the source data are handled.
+
+```julia
+resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var, nan_threshold = 0.5)
+```
+
+By default, a resampled value is `NaN` whenever any of the values it
+interpolates from is `NaN`, so a few `NaN`s in the source data can spread to
+many points in the resampled data. For example, when resampling data that is
+only defined over the land and is `NaN` over the ocean, values near the
+coastlines become `NaN`. Passing a value from 0 to 1 for `nan_threshold` fix
+this problem. For more information, see the section "How do I resample data
+that contains NaNs?" in the documentation.
+
 v0.5.23
 -------
 

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -241,6 +241,12 @@ dimensions in either `OutputVar`s are missing units, the dimensions between the
 `OutputVar`s do not agree, or the data in `src_var` is not defined everywhere on
 the dimensions in `dest_var`.
 
+!!! tip "Resampling data with NaNs"
+    If the data contains `NaN`s, then consider passing the keyword argument
+    `nan_threshold` to prevent `NaN`s from spreading in the resampled data.
+    See [How do I resample data that contains NaNs?](@ref) for more
+    information.
+
 ```@setup resampled_as
 import ClimaAnalysis
 import OrderedCollections: OrderedDict
@@ -266,6 +272,10 @@ time_dims = OrderedDict("time" => [0.0, 86400.0, 172800.0])
 time_dim_attribs = OrderedDict("time" => Dict("units" => "s"))
 time_attribs = Dict("long_name" => "hi", "start_date" => "2010-01-01")
 time_var = ClimaAnalysis.OutputVar(time_attribs, time_dims, time_dim_attribs, [1.0, 2.0, 3.0])
+
+nan_data = reshape(1.0:12.0, (3, 4)) |> Array
+nan_data[2, 2] = NaN
+nan_var = ClimaAnalysis.OutputVar(src_attribs, src_dims, src_dim_attribs, nan_data)
 ```
 
 ```@repl resampled_as
@@ -329,6 +339,24 @@ resampled_var = ClimaAnalysis.resampled_as(
 );
 resampled_var.data
 ClimaAnalysis.dates(resampled_var)
+```
+
+## How do I resample data that contains NaNs?
+
+!!! compat "`nan_threshold` keyword argument"
+    The keyword argument `nan_threshold` for `resampled_as` is introduced
+    after ClimaAnalysis v0.5.23.
+
+You can pass a value ranging from zero to one for the `nan_threshold` keyword argument to
+limit the `NaN`s propagating when resampling. Higher values for the `nan_threshold` keyword
+argument result in less `NaN`s in the resampled data at the cost of resampling from fewer
+points. We recommend passing `nothing` for `nan_threshold` when the data does not contain
+`NaN`s, since resampling is faster in that case.
+
+```@repl resampled_as
+nan_var.data
+ClimaAnalysis.resampled_as(nan_var, dest_var).data # no NaN-aware resampling
+ClimaAnalysis.resampled_as(nan_var, dest_var, nan_threshold = 0.5).data # NaN-aware resampling
 ```
 
 ## How do I load multiple NetCDF files along the time dimension?

--- a/docs/src/var.md
+++ b/docs/src/var.md
@@ -146,6 +146,12 @@ and latitude dimensions, a periodic boundary condition and a flat boundary condi
 added, respectively, when the dimension array is equispaced and spans the entire range. For
 all other cases, extrapolating beyond the domain of the dimension will throw an error.
 
+!!! tip "Resampling data with NaNs"
+    By default, `NaN`s in the data propagate through interpolation. When resampling with
+    `resampled_as`, you can pass the keyword argument `nan_threshold` to prevent `NaN`s
+    from spreading in the resampled data. See
+    [How do I resample data that contains NaNs?](@ref) for more information.
+
 ## Preprocess dates and seconds
 When loading a NetCDF file, dates in the time dimension are automatically converted to
 seconds and a start date is added to the attributes of the `OutputVar`. This is done because

--- a/src/Interpolation.jl
+++ b/src/Interpolation.jl
@@ -66,6 +66,35 @@ Linear interpolation, where NaNs propagate through the weighted sum.
 struct LinearInterpolation <: AbstractInterpolationMethod end
 
 """
+    NaNLinearInterpolation(threshold = 0.5)
+
+Linear interpolation that is aware of NaNs in the source data. The `threshold`
+must be between zero and one.
+
+For each interpolated point, the interpolation weights of the NaN values are
+summed. If this sum is greater than the `threshold`, the result is `NaN`.
+Otherwise, the result is the weighted sum of the non-NaN values renormalized by
+the sum of their weights.
+
+A `threshold` of zero means any `NaN` with a nonzero weight in the interpolation
+produces `NaN`, and a `threshold` of one means the result is `NaN` only when all
+the values with nonzero weights in the interpolation are `NaN`.
+
+A `missing` value anywhere in the interpolation produces `missing`, regardless
+of its weight or the `threshold`.
+"""
+struct NaNLinearInterpolation{FT <: AbstractFloat} <:
+       AbstractInterpolationMethod
+    threshold::FT
+    function NaNLinearInterpolation(threshold::Real = 0.5)
+        0 <= threshold <= 1 ||
+            error("Threshold ($threshold) must be between 0 and 1")
+        threshold = float(threshold)
+        return new{typeof(threshold)}(threshold)
+    end
+end
+
+"""
     Regridder
 
 Linearly interpolate gridded data with support for node and centers and throw,
@@ -94,7 +123,7 @@ struct Regridder{
     cell edges (`Node`)."
     staggering::S
 
-    "Interpolation method (`LinearInterpolation`)"
+    "Interpolation method (`LinearInterpolation` or `NaNLinearInterpolation`)"
     method::M
 end
 
@@ -117,6 +146,9 @@ iterable of `Node` or `Center`, one entry per dimension.
 
 The number of dimensions of `src_data` and `src_grid` and the length of
 `extrapolation` and `staggering` must all be the same.
+
+The keyword `method` (`LinearInterpolation` or `NaNLinearInterpolation`)
+determines how NaNs in `src_data` are handled.
 """
 function Regridder(
     src_data::AbstractArray,
@@ -331,6 +363,59 @@ Compute a single value for linear interpolation for a single point using the
     # This is needed for the interpolate and interpolate! to return the same
     # type as regrid and regrid!
     return T(acc)
+end
+
+"""
+    _apply_stencils(
+        ::Type{T},
+        src_data::AbstractArray,
+        stencils,
+        method::NaNLinearInterpolation,
+    ) where {T}
+
+Compute a single value for `NaN`-aware linear interpolation for a single point using the
+`stencils` and `src_data`.
+
+For more details, see `NaNLinearInterpolation`.
+"""
+@inline function _apply_stencils(
+    ::Type{T},
+    src_data::AbstractArray,
+    stencils,
+    method::NaNLinearInterpolation,
+) where {T}
+    N = length(stencils)
+    # Iterate over all 2^N corners and compute a weighted average
+    corners = CartesianIndices(ntuple(_ -> 2, Val(N)))
+    acc = zero(T)
+    nan_weight = zero(T)
+    valid_weight = zero(T)
+    @inbounds for corner in corners
+        idx = ntuple(
+            d -> corner[d] == 1 ? stencils[d][1] : stencils[d][2],
+            Val(N),
+        )
+        w = one(stencils[1][3])
+        for d in 1:N
+            w *= corner[d] == 1 ? stencils[d][3] : one(w) - stencils[d][3]
+        end
+        v = src_data[idx...]
+        # A missing value propagates through the weighted sum
+        ismissing(v) && return missing
+        if isnan(v)
+            nan_weight += w
+        else
+            valid_weight += w
+            acc += w * v
+        end
+    end
+    nan_weight > method.threshold && return T(NaN)
+    # We cannot divide by 1 - nan_weight because nan_weight might be less than 1
+    # due to floating point round off errors. This prevent the cases when
+    # acc = 0 and 1 - nan_weight is close but not exactly 1 which would give 0
+    # instead of NaN
+    divisor = ifelse(iszero(nan_weight), one(T), valid_weight)
+    return T(acc / divisor)
 end
 
 # All stencil functions return (index1, index2, w) where w is the weight used to

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -118,7 +118,7 @@ include("flat.jl")
 const HasDimAndAttribs = Union{OutputVar, FlatVar, Metadata}
 
 """
-    _make_regridder(dims, data)
+    _make_regridder(dims, data; nan_threshold = nothing)
 
 Make a `Interpolation.Regridder` from `dims`, a dictionary mapping dimension name to array
 and `data`, an array containing data.
@@ -129,8 +129,12 @@ are equispaced, then a periodic boundary condition is added for the longitude di
 the latitudes span the entire range and are equispaced, then a flat boundary condition is
 added for the latitude dimension. In all other cases, an error is thrown when extrapolating
 outside of `dim_array`.
+
+If `nan_threshold` is `nothing`, the regridder uses `Interpolation.LinearInterpolation`.
+Otherwise, it uses `Interpolation.NaNLinearInterpolation` with `nan_threshold` as the
+threshold.
 """
-function _make_regridder(dims, data)
+function _make_regridder(dims, data; nan_threshold = nothing)
     # If any element is DateTime, then return nothing for the regridder because
     # regridding on dates is not supported
     for dim_array in values(dims)
@@ -157,11 +161,16 @@ function _make_regridder(dims, data)
         (dim_name, dim_array) in dims
     ]
 
+    method =
+        isnothing(nan_threshold) ? Interpolation.LinearInterpolation() :
+        Interpolation.NaNLinearInterpolation(nan_threshold)
+
     return Interpolation.Regridder(
         data,
         Tuple(values(dims)),
         Tuple(first.(extp_and_stag)),
-        Tuple(last.(extp_and_stag)),
+        Tuple(last.(extp_and_stag));
+        method,
     )
 end
 
@@ -1604,7 +1613,12 @@ function reordered_as(src_var::OutputVar, dest_var::OutputVar)
 end
 
 """
-    resampled_as(src_var::OutputVar, dest_var::OutputVar, dim_names = nothing)
+    resampled_as(
+        src_var::OutputVar,
+        dest_var::OutputVar;
+        dim_names = nothing,
+        nan_threshold = nothing,
+    )
 
 Resample `data` in `src_var` to `dims` in `dest_var`.
 
@@ -1612,6 +1626,42 @@ The resampling performed here is a 1st-order linear resampling.
 
 If the string or iterable `dim_names` is `nothing`, then resampling is done over all
 dimensions. Otherwise, resampling is done over the dimensions in `dim_names`.
+
+The keyword argument `nan_threshold` is the fraction of `NaN`s allowed when computing a
+resampled value. If `nan_threshold` is `nothing`, then linear interpolation is used. Higher
+values of `nan_threshold` result in fewer `NaN`s in the resampled data at the cost of
+resampling from fewer points. A `nan_threshold` of zero means the result is `NaN` whenever a
+`NaN` contributes to the average, and a `nan_threshold` of one means the result is `NaN`
+only when every value contributing to the average is `NaN`. If there are no `NaN`s in the
+data, we recommend passing `nothing` for `nan_threshold`, since it is faster.
+
+!!! details "How `nan_threshold` works"
+    Linear resampling computes each resampled value as a weighted average of the values at
+    the nearest points of the source grid, where closer points contribute more to the
+    average. If `nan_threshold` is `nothing`, a resampled value is `NaN` whenever any value
+    in its average is `NaN`. If a number between zero and one is passed, then for each
+    resampled point, `nan_threshold` is compared against the fraction of the average that
+    comes from `NaN` values. If this fraction is greater than `nan_threshold`, the result
+    is `NaN`. Otherwise, the `NaN`s are discarded, and the result is the weighted average
+    of the remaining values. A `nan_threshold` of zero means the result is `NaN` whenever a
+    `NaN` contributes to the average, and a `nan_threshold` of one means the result is
+    `NaN` only when every value contributing to the average is `NaN`.
+
+    For example, consider the one-dimensional case with the value `2.0` at `x = 0.0` and
+    `NaN` at `x = 1.0`. Resampling at `x = 0.25` computes `0.75 * 2.0 + 0.25 * NaN`, so 25%
+    of the average comes from a `NaN`. With `nan_threshold = 0.5`, the `NaN` is discarded,
+    and the result is `2.0`, the average of the remaining values. Resampling at `x = 0.75`
+    computes `0.25 * 2.0 + 0.75 * NaN`, so 75% of the average comes from a `NaN`, which is
+    greater than the threshold, and the result is `NaN`.
+
+`NaN`-aware resampling is useful when handling with data that is only defined over the land
+or ocean and everything else is `NaN`. With the default behavior, values near the coastlines
+become `NaN` after resampling.
+
+!!! note "Missing values"
+    The keyword argument `nan_threshold` does not affect `missing` values and `missing`
+    values propagate. If this is a problem, replace them with `NaN` first (e.g.,
+    `replace(var, missing => NaN)`, see [`replace`](@ref) and [`replace!`](@ref)).
 
 !!! note "Automatic reordering"
     If resampling is done over all dimensions, then reordering the dimensions of the
@@ -1626,6 +1676,9 @@ longitude dimension because `conventional_dim_name` maps `lon`, `long`, and `lon
 !!! compat "`dim_names` keyword argument"
     The keyword argument `dim_names` is introduced in ClimaAnalysis v0.5.14.
 
+!!! compat "`nan_threshold` keyword argument"
+    The keyword argument `nan_threshold` is introduced after ClimaAnalysis v0.5.23.
+
 !!! note "Reference date"
     If `src_var` and `dest_var` do not have the same reference or start date,
     then the reference date of `src_var` is set to the reference date of
@@ -1635,6 +1688,7 @@ function resampled_as(
     src_var::OutputVar,
     dest_var::OutputVar;
     dim_names = nothing,
+    nan_threshold = nothing,
 )
     if dim_names isa AbstractString
         dim_names = [dim_names]
@@ -1644,7 +1698,7 @@ function resampled_as(
 
     # If dim_names is nothing, then resample over all dimensions
     if isnothing(dim_names)
-        return _resampled_as_all(src_var, dest_var)
+        return _resampled_as_all(src_var, dest_var, nan_threshold)
     end
 
     # If the dimensions are the same between both OutputVars and dim_names are the same as
@@ -1654,20 +1708,24 @@ function resampled_as(
     conventional_dim_names = Set(conventional_dim_name.(dim_names))
     if (src_var_dim_names == dest_var_dim_names) &&
        (src_var_dim_names == conventional_dim_names)
-        return _resampled_as_all(src_var, dest_var)
+        return _resampled_as_all(src_var, dest_var, nan_threshold)
     end
 
-    return _resampled_as_partial(src_var, dest_var, dim_names)
+    return _resampled_as_partial(src_var, dest_var, dim_names, nan_threshold)
 end
 
 """
-    _resampled_as_all(src_var::OutputVar, dest_var::OutputVar)
+    _resampled_as_all(src_var::OutputVar, dest_var::OutputVar, nan_threshold)
 
 Resample `data` in `src_var` to `dims` in `dest_var` over all dimensions.
 
 Reordering is automatically done.
 """
-function _resampled_as_all(src_var::OutputVar, dest_var::OutputVar)
+function _resampled_as_all(
+    src_var::OutputVar,
+    dest_var::OutputVar,
+    nan_threshold,
+)
     conventional_names_src = collect(conventional_dim_name.(keys(src_var.dims)))
     conventional_names_dest =
         collect(conventional_dim_name.(keys(dest_var.dims)))
@@ -1678,7 +1736,7 @@ function _resampled_as_all(src_var::OutputVar, dest_var::OutputVar)
         src_var = reordered_as(src_var, dest_var)
     end
 
-    regridder = _make_regridder(src_var.dims, src_var.data)
+    regridder = _make_regridder(src_var.dims, src_var.data; nan_threshold)
     src_resampled_data =
         Interpolation.regrid(regridder, Tuple(values(dest_var.dims)))
 
@@ -1694,7 +1752,12 @@ function _resampled_as_all(src_var::OutputVar, dest_var::OutputVar)
 end
 
 """
-    _resampled_as_partial(src_var::OutputVar, dest_var::OutputVar, dim_names...)
+    _resampled_as_partial(
+        src_var::OutputVar,
+        dest_var::OutputVar,
+        dim_names,
+        nan_threshold,
+    )
 
 Resample `data` in `src_var` to `dim_names` in `dest_var`.
 
@@ -1707,6 +1770,7 @@ function _resampled_as_partial(
     src_var::OutputVar,
     dest_var::OutputVar,
     dim_names,
+    nan_threshold,
 )
     dim_names = conventional_dim_name.(collect(dim_names))
 
@@ -1726,7 +1790,7 @@ function _resampled_as_partial(
         end
     end
 
-    regridder = _make_regridder(src_var.dims, src_var.data)
+    regridder = _make_regridder(src_var.dims, src_var.data; nan_threshold)
     src_resampled_data =
         Interpolation.regrid(regridder, Tuple(values(src_var_ret_dims)))
 
@@ -1734,7 +1798,7 @@ function _resampled_as_partial(
 end
 
 """
-    resampled_as(src_var::OutputVar, kwargs...)
+    resampled_as(src_var::OutputVar; nan_threshold = nothing, kwargs...)
 
 Resample `data` in `src_var` to dimensions as defined by the keyword arguments.
 
@@ -1742,6 +1806,10 @@ The resampling performed here is a 1st-order linear resampling.
 
 For example, to resample on the longitude dimension of `[0.0, 1.0, 2.0]`, one can do
 `resampled_as(src_var, lon = [0.0, 1.0, 2.0])`.
+
+See the docstring of [`resampled_as(src_var::OutputVar, dest_var::OutputVar)`](@ref) for
+how the keyword argument `nan_threshold` controls the handling of `NaN`s in the data of
+`src_var`.
 
 If the dimensions in `dims` and `src_var.dims` match (ignoring order), the resulting
 `OutputVar` will have its dimensions reordered to match the order in `dims`. Otherwise, the
@@ -1756,8 +1824,11 @@ Note that there is no checking for units of the dimensions.
 !!! compat "Support for dates"
     Passing dates for the time dimension is introduced after ClimaAnalysis
     v0.5.22.
+
+!!! compat "`nan_threshold` keyword argument"
+    The keyword argument `nan_threshold` is introduced after ClimaAnalysis v0.5.23.
 """
-function resampled_as(src_var::OutputVar; kwargs...)
+function resampled_as(src_var::OutputVar; nan_threshold = nothing, kwargs...)
     # If the values are dates, then compute the associated times before resampling
     function _kwarg_to_dim_pair(dim_name, dim_array)
         dim_name = String(dim_name)
@@ -1805,9 +1876,16 @@ function resampled_as(src_var::OutputVar; kwargs...)
     )
 
     # Do not pass to resampled_as as we do not want to check units
-    return length(dest_dims) == length(src_var.dims) ?
-           _resampled_as_all(src_var, dest_var) :
-           _resampled_as_partial(src_var, dest_var, keys(dest_dims))
+    if length(dest_dims) == length(src_var.dims)
+        return _resampled_as_all(src_var, dest_var, nan_threshold)
+    else
+        return _resampled_as_partial(
+            src_var,
+            dest_var,
+            keys(dest_dims),
+            nan_threshold,
+        )
+    end
 end
 
 """
@@ -2259,11 +2337,20 @@ See also [`global_bias`](@ref), [`squared_error`](@ref), [`global_mse`](@ref),
 function bias(sim::OutputVar, obs::OutputVar; mask = nothing)
     _check_sim_obs_units_consistent(sim, obs, 2)
 
+    # Reorder the dimensions in obs to match sim so that identical grids are detected by
+    # arecompatible regardless of the order of the dimensions
+    conventional_dim_name.(dim_names(obs)) !=
+    conventional_dim_name.(dim_names(sim)) && (obs = reordered_as(obs, sim))
+
     # Resample obs on sim to ensure the size of data in sim and obs are the same and the
     # dims are the same
-    any(isnan, obs.data) &&
-        @warn "NaNs detected in observational data, resampling is not NaN aware. If you applied a mask, pass the mask via the mask keyword argument instead"
-    obs_resampled = resampled_as(obs, sim)
+    if arecompatible(sim, obs)
+        obs_resampled = obs
+    else
+        any(isnan, obs.data) &&
+            @warn "NaNs detected in observational data, resampling is not NaN aware. If you applied a mask, pass the mask via the mask keyword argument instead. For versions of ClimaAnalysis after v0.5.23, you can resample using resampled_as(obs, sim; nan_threshold = ...) to do NaN-aware resampling before calling this function"
+        obs_resampled = resampled_as(obs, sim)
+    end
 
     # Compute bias
     bias = sim - obs_resampled
@@ -2346,10 +2433,19 @@ See also [`global_mse`](@ref), [`global_rmse`](@ref), [`bias`](@ref), [`global_b
 function squared_error(sim::OutputVar, obs::OutputVar; mask = nothing)
     _check_sim_obs_units_consistent(sim, obs, 2)
 
+    # Reorder the dimensions in obs to match sim so that identical grids are detected by
+    # arecompatible regardless of the order of the dimensions
+    conventional_dim_name.(dim_names(obs)) !=
+    conventional_dim_name.(dim_names(sim)) && (obs = reordered_as(obs, sim))
+
     # Resample obs on sim to ensure the size of data in sim and obs are the same and the dims are the same
-    any(isnan, obs.data) &&
-        @warn "NaNs detected in observational data, resampling is not NaN aware. If you applied a mask, pass the mask via the mask keyword argument instead"
-    obs_resampled = resampled_as(obs, sim)
+    if arecompatible(sim, obs)
+        obs_resampled = obs
+    else
+        any(isnan, obs.data) &&
+            @warn "NaNs detected in observational data, resampling is not NaN aware. If you applied a mask, pass the mask via the mask keyword argument instead. For versions of ClimaAnalysis after v0.5.23, you can resample using resampled_as(obs, sim; nan_threshold = ...) to do NaN-aware resampling before calling this function"
+        obs_resampled = resampled_as(obs, sim)
+    end
 
     # Compute squared error
     # Do not use ^ since ^ is not defined between a OutputVar and Real

--- a/src/masks.jl
+++ b/src/masks.jl
@@ -168,7 +168,7 @@ function _generate_binary_mask(mask_var::LonLatMask, var::OutputVar)
     # Use _resampled_as_partial as we do not want to do units checking as
     # it would be too restrictive
     resampled_mask_var =
-        _resampled_as_partial(mask_var.output_var, var, ("lon", "lat"))
+        _resampled_as_partial(mask_var.output_var, var, ("lon", "lat"), nothing)
 
     mask = copy(resampled_mask_var.data)
     # Reshape data for broadcasting

--- a/test/test_Numerics.jl
+++ b/test/test_Numerics.jl
@@ -237,6 +237,20 @@ end
         stag,
     )
 
+    # NaN and missing values in coordinates are not supported
+    @test_throws "Missing or NaN values" Intp.Regridder(
+        data,
+        ([1.0, NaN, 3.0], [4.0, 5.0, 6.0]),
+        extp,
+        stag,
+    )
+    @test_throws "Missing or NaN values" Intp.Regridder(
+        data,
+        ([1.0, 2.0, 3.0], Union{Missing, Float64}[4.0, missing, 6.0]),
+        extp,
+        stag,
+    )
+
     # Period must be positive and not smaller than the span of the coordinates
     @test_throws "is not positive" Intp.Regridder(
         data,
@@ -443,6 +457,316 @@ end
     # A point has to have as many coordinates as the regridder has dimensions
     @test_throws MethodError Intp.interpolate(regridder, (1.0,))
     @test_throws MethodError Intp.interpolate(regridder, (1.0, 4.0, 7.0))
+end
+
+@testset "NaN-aware regridding" begin
+    @test Intp.NaNLinearInterpolation().threshold == 0.5
+    @test Intp.NaNLinearInterpolation(0).threshold === 0.0
+    @test Intp.NaNLinearInterpolation(1.0).threshold === 1.0
+    @test Intp.NaNLinearInterpolation(1 // 2).threshold === 0.5
+    # Threshold must be between 0 and 1
+    @test_throws "must be between 0 and 1" Intp.NaNLinearInterpolation(-0.5)
+    @test_throws "must be between 0 and 1" Intp.NaNLinearInterpolation(1.5)
+    @test_throws "must be between 0 and 1" Intp.NaNLinearInterpolation(NaN)
+
+    # extp and stag apply to every dimension unless given as tuples
+    function make_regridder(
+        data,
+        coords;
+        extp = Intp.Throw(),
+        stag = Intp.Node(),
+        threshold = 0.5,
+    )
+        n = length(coords)
+        return Intp.Regridder(
+            data,
+            coords,
+            extp isa Tuple ? extp : ntuple(_ -> extp, n),
+            stag isa Tuple ? stag : ntuple(_ -> stag, n),
+            method = Intp.NaNLinearInterpolation(threshold),
+        )
+    end
+
+    # 1D
+    coords = ([1.0, 2.0, 3.0],)
+    data = [1.0, NaN, 3.0]
+    nan_regridder(threshold) = make_regridder(data, coords; threshold)
+
+    # NaN with zero weight does not affect the result for any threshold
+    for threshold in (0.0, 0.5, 1.0)
+        @test Intp.interpolate(nan_regridder(threshold), (1.0,)) == 1.0
+    end
+
+    # NaN weight is 0.5: below, at, and above the threshold
+    @test isnan(Intp.interpolate(nan_regridder(0.25), (1.5,)))
+    # Exceeding the threshold means strictly greater
+    @test Intp.interpolate(nan_regridder(0.5), (1.5,)) == 1.0
+    @test Intp.interpolate(nan_regridder(0.75), (1.5,)) == 1.0
+    # Weights are renormalized by the sum of the non-NaN weights
+    @test Intp.interpolate(nan_regridder(0.75), (1.25,)) == 1.0
+    @test Intp.interpolate(nan_regridder(0.75), (2.75,)) == 3.0
+
+    # NaN weight is 1, so the result is NaN even when the threshold is 1
+    @test isnan(Intp.interpolate(nan_regridder(1.0), (2.0,)))
+
+    # Regridding onto the source grid reproduces the data, including NaNs
+    @test Intp.regrid(nan_regridder(0.5), coords) ≈ data nans = true
+
+    # Interpolating a vector of points
+    @test isequal(
+        Intp.interpolate(nan_regridder(0.5), [(1.0,), (1.5,), (2.0,)]),
+        [1.0, 1.0, NaN],
+    )
+
+    # Renormalization returns the only non-NaN value when the threshold is not
+    # exceeded
+    sparse = make_regridder([NaN, 2.0, NaN], coords)
+    @test Intp.interpolate(sparse, (1.5,)) == 2.0
+    @test Intp.interpolate(sparse, (2.5,)) == 2.0
+    @test isnan(Intp.interpolate(sparse, (1.25,)))
+
+    # regrid! into a Float32 destination array converts values and NaNs
+    dest32 = zeros(Float32, 2)
+    Intp.regrid!(dest32, nan_regridder(0.25), ([1.0, 1.5],))
+    @test dest32[1] === 1.0f0
+    @test isnan(dest32[2])
+
+    # All NaN source data produces NaN for any threshold
+    all_nan = make_regridder([NaN, NaN, NaN], coords, threshold = 1.0)
+    @test all(isnan, Intp.regrid(all_nan, ([1.0, 1.5, 2.0, 3.0],)))
+
+    # nan_weight = 0.9999999999999999, so acc / (1 - nan_weight) gives zero
+    # instead of NaN
+    unit_square = ([0.0, 1.0], [0.0, 1.0])
+    all_nan2d = make_regridder(fill(NaN, (2, 2)), unit_square, threshold = 1.0)
+    @test isnan(Intp.interpolate(all_nan2d, (0.3, 0.4)))
+
+    # Without NaNs, NaNLinearInterpolation agrees with LinearInterpolation
+    src_grid = ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    data2d = collect(reshape(1.0:9.0, (3, 3)))
+    dest_grid = ([1.0, 1.5, 2.5, 3.0], [4.0, 4.5, 5.5, 6.0])
+    linear = Intp.Regridder(
+        data2d,
+        src_grid,
+        (Intp.Throw(), Intp.Throw()),
+        (Intp.Node(), Intp.Node()),
+    )
+    nan_linear = make_regridder(data2d, src_grid)
+    @test Intp.regrid(nan_linear, dest_grid) == Intp.regrid(linear, dest_grid)
+
+    # TODO: Review this
+    # 2D with a single NaN: the query point (1.5, 4.5) weights all four
+    # corners by 0.25
+    data_nan = collect(reshape(1.0:9.0, (3, 3)))
+    data_nan[1, 1] = NaN
+    nan2d(threshold) = make_regridder(data_nan, src_grid; threshold)
+    # (2 + 4 + 5) * 0.25 / 0.75
+    @test Intp.interpolate(nan2d(0.25), (1.5, 4.5)) ≈ 11.0 / 3.0
+    @test isnan(Intp.interpolate(nan2d(0.2), (1.5, 4.5)))
+    # Points on the grid away from the NaN are unaffected
+    @test Intp.interpolate(nan2d(0.0), (2.0, 5.0)) == 5.0
+    @test isnan(Intp.interpolate(nan2d(0.0), (1.0, 4.0)))
+
+    # Asymmetric weights: the query point (1.5, 4.25) weights the NaN corner
+    # by 0.375, so the result is (2 * 0.375 + 4 * 0.125 + 5 * 0.125) / 0.625
+    @test Intp.interpolate(nan2d(0.375), (1.5, 4.25)) == 3.0
+    @test isnan(Intp.interpolate(nan2d(0.25), (1.5, 4.25)))
+
+    # 2D with two NaNs: NaN weight at (1.5, 4.5) is 0.5
+    data_nan2 = collect(reshape(1.0:9.0, (3, 3)))
+    data_nan2[1, 1] = NaN
+    data_nan2[2, 2] = NaN
+    nan2d_two(threshold) = make_regridder(data_nan2, src_grid; threshold)
+    # (2 + 4) * 0.25 / 0.5
+    @test Intp.interpolate(nan2d_two(0.5), (1.5, 4.5)) == 3.0
+    @test isnan(Intp.interpolate(nan2d_two(0.25), (1.5, 4.5)))
+
+    # 2D with three NaN corners: only one valid corner remains
+    data_nan3 = collect(reshape(1.0:9.0, (3, 3)))
+    data_nan3[1, 1] = NaN
+    data_nan3[2, 1] = NaN
+    data_nan3[1, 2] = NaN
+    nan2d_three(threshold) = make_regridder(data_nan3, src_grid; threshold)
+    @test Intp.interpolate(nan2d_three(0.75), (1.5, 4.5)) == 5.0
+    @test isnan(Intp.interpolate(nan2d_three(0.5), (1.5, 4.5)))
+
+    # 2D with all four NaN corners: NaN even when the threshold is 1
+    data_nan4 = copy(data_nan3)
+    data_nan4[2, 2] = NaN
+    nan2d_four = make_regridder(data_nan4, src_grid, threshold = 1.0)
+    @test isnan(Intp.interpolate(nan2d_four, (1.5, 4.5)))
+
+    # 3D with one NaN corner: the center of the cell weights all eight corners
+    # by 0.125
+    data3d = collect(reshape(1.0:8.0, (2, 2, 2)))
+    data3d[1, 1, 1] = NaN
+    nan3d(threshold) =
+        make_regridder(data3d, ([1.0, 2.0], [1.0, 2.0], [1.0, 2.0]); threshold)
+    # (2 + 3 + ... + 8) * 0.125 / 0.875
+    @test Intp.interpolate(nan3d(0.125), (1.5, 1.5, 1.5)) == 5.0
+    @test isnan(Intp.interpolate(nan3d(0.1), (1.5, 1.5, 1.5)))
+
+    # regrid, regrid!, and interpolate agree
+    expected = [
+        Intp.interpolate(nan2d(0.25), (x, y)) for
+        x in dest_grid[1], y in dest_grid[2]
+    ]
+    regridded = Intp.regrid(nan2d(0.25), dest_grid)
+    @test regridded ≈ expected nans = true
+    dest_data = zeros(4, 4)
+    Intp.regrid!(dest_data, nan2d(0.25), dest_grid)
+    @test dest_data ≈ expected nans = true
+
+    # Extrapolation conditions apply per dimension with NaN handling
+    lon_grid = [0.0, 90.0, 180.0, 270.0]
+    data_mixed = collect(reshape(1.0:12.0, (4, 3)))
+    data_mixed[1, 1] = NaN
+    mixed_extp(threshold) = make_regridder(
+        data_mixed,
+        (lon_grid, [4.0, 5.0, 6.0]);
+        extp = (Intp.Periodic(360.0), Intp.Flat()),
+        threshold,
+    )
+    # The wrap gap interpolates between the last (4.0) and first (NaN) points
+    @test Intp.interpolate(mixed_extp(0.5), (315.0, 4.0)) == 4.0
+    @test isnan(Intp.interpolate(mixed_extp(0.25), (315.0, 4.0)))
+    # Outside the flat dimension, away from the NaN
+    @test Intp.interpolate(mixed_extp(0.5), (315.0, 8.0)) == 10.5
+    # Outside the flat dimension, next to the NaN
+    @test Intp.interpolate(mixed_extp(0.5), (45.0, 3.0)) == 2.0
+
+    # NaN-aware interpolation with periodic and flat boundary conditions
+    lon = [0.0, 90.0, 180.0, 270.0]
+    data_periodic = [NaN, 2.0, 3.0, 4.0]
+    periodic =
+        make_regridder(data_periodic, (lon,), extp = Intp.Periodic(360.0))
+    # Interpolating across the wrap gap (270, 360) between 4.0 and NaN
+    @test Intp.interpolate(periodic, (315.0,)) == 4.0
+    @test isnan(Intp.interpolate(periodic, (350.0,)))
+
+    # NaN at the duplicated periodic endpoint
+    lon_dup = [0.0, 90.0, 180.0, 270.0, 360.0]
+    periodic_dup = make_regridder(
+        [1.0, 2.0, 3.0, 4.0, NaN],
+        (lon_dup,),
+        extp = Intp.Periodic(360.0),
+    )
+    @test Intp.interpolate(periodic_dup, (0.0,)) == 1.0
+    @test isnan(Intp.interpolate(periodic_dup, (360.0,)))
+    # Wrapped queries interpolate against the NaN endpoint
+    @test Intp.interpolate(periodic_dup, (-45.0,)) == 4.0
+    # Queries wrapped by whole periods
+    @test Intp.interpolate(periodic_dup, (720.0,)) == 1.0
+    @test Intp.interpolate(periodic_dup, (-405.0,)) == 4.0
+
+    # Interpolating across the wrap gap with Center staggering
+    lon_center = [45.0, 135.0, 225.0, 315.0]
+    periodic_center(threshold) = make_regridder(
+        [1.0, 2.0, 3.0, NaN],
+        (lon_center,);
+        extp = Intp.Periodic(360.0),
+        stag = Intp.Center(),
+        threshold,
+    )
+    # The point 0.0 is midway between the last (NaN) and first coordinates
+    @test Intp.interpolate(periodic_center(0.5), (0.0,)) == 1.0
+    @test isnan(Intp.interpolate(periodic_center(0.25), (0.0,)))
+
+    flat = make_regridder([NaN, 2.0, 3.0], coords, extp = Intp.Flat())
+    @test isnan(Intp.interpolate(flat, (0.0,)))
+    @test Intp.interpolate(flat, (4.0,)) == 3.0
+    # A NaN query coordinate produces NaN
+    @test isnan(Intp.interpolate(flat, (NaN,)))
+
+    # Flat with Center staggering behaves the same as with Node
+    flat_center = make_regridder(
+        [NaN, 2.0, 3.0],
+        coords,
+        extp = Intp.Flat(),
+        stag = Intp.Center(),
+    )
+    @test isnan(Intp.interpolate(flat_center, (0.5,)))
+    @test Intp.interpolate(flat_center, (3.75,)) == 3.0
+
+    # With Center staggering and Throw, the half-cell margins extrapolate with
+    # weights outside [0, 1]
+    throw_center(data, threshold) =
+        make_regridder(data, coords; stag = Intp.Center(), threshold)
+    # A NaN at the near boundary has weight greater than one, so the result is
+    # NaN for any threshold
+    @test isnan(Intp.interpolate(throw_center([NaN, 2.0, 3.0], 1.0), (0.75,)))
+    @test isnan(Intp.interpolate(throw_center([1.0, 2.0, NaN], 1.0), (3.25,)))
+    # A NaN at the far point has negative weight, so it is excluded and the
+    # result degrades to the boundary value
+    @test Intp.interpolate(throw_center([1.0, NaN, 3.0], 0.0), (0.75,)) == 1.0
+    @test Intp.interpolate(throw_center([1.0, NaN, 3.0], 0.0), (3.25,)) == 3.0
+    # A missing value propagates even from an extrapolated corner
+    @test ismissing(
+        Intp.interpolate(
+            throw_center(Union{Missing, Float64}[1.0, missing, 3.0], 0.0),
+            (0.75,),
+        ),
+    )
+    # Out-of-domain queries still throw regardless of NaNs
+    @test_throws DomainError Intp.interpolate(
+        throw_center([NaN, 2.0, 3.0], 1.0),
+        (0.25,),
+    )
+
+    # Missing values propagate through the weighted sum, like with
+    # LinearInterpolation
+    grid4 = ([1.0, 2.0, 3.0, 4.0],)
+    data_missing = Union{Missing, Float64}[1.0, 2.0, missing, 4.0]
+    missing_regridder(threshold) =
+        make_regridder(data_missing, grid4; threshold)
+    # Stencils away from the missing value are unaffected
+    @test Intp.interpolate(missing_regridder(0.5), (1.5,)) == 1.5
+    # Missing propagates for any threshold and any weight, including zero
+    @test ismissing(Intp.interpolate(missing_regridder(1.0), (2.5,)))
+    @test ismissing(Intp.interpolate(missing_regridder(1.0), (3.0,)))
+    @test ismissing(Intp.interpolate(missing_regridder(1.0), (4.0,)))
+    # The eltype of the destination data includes Missing
+    out = Intp.regrid(missing_regridder(0.5), ([1.5, 2.5],))
+    @test eltype(out) == Union{Missing, Float64}
+    @test out[1] == 1.5
+    @test ismissing(out[2])
+
+    # NaN handling applies alongside missing propagation: the NaN is excluded,
+    # the missing propagates
+    nan_missing =
+        make_regridder(Union{Missing, Float64}[1.0, NaN, missing, 4.0], grid4)
+    @test Intp.interpolate(nan_missing, (1.5,)) == 1.0
+    @test ismissing(Intp.interpolate(nan_missing, (2.5,)))
+    @test ismissing(Intp.interpolate(nan_missing, (3.5,)))
+
+    # All missing source data produces missing
+    all_missing = make_regridder(
+        Vector{Union{Missing, Float64}}(missing, 3),
+        coords,
+        threshold = 1.0,
+    )
+    @test all(ismissing, Intp.regrid(all_missing, ([1.0, 1.5, 2.0],)))
+
+    # Integer source data with missing keeps Missing in the eltype
+    int_missing = make_regridder(
+        Union{Missing, Int}[1, missing, 3],
+        coords,
+        threshold = 0.75,
+    )
+    @test ismissing(Intp.interpolate(int_missing, (1.25,)))
+    @test eltype(Intp.regrid(int_missing, ([1.25],))) == Union{Missing, Float64}
+
+    # Float32 source data keeps its element type
+    nan32 = make_regridder(Float32[1.0, NaN, 3.0], ([1.0f0, 2.0f0, 3.0f0],))
+    @test Intp.interpolate(nan32, (1.5f0,)) === 1.0f0
+    @test eltype(Intp.regrid(nan32, (Float32[1.5],))) == Float32
+
+    # Integer source data cannot contain NaN and produces floating point data,
+    # matching LinearInterpolation
+    int_nan = make_regridder(reshape(1:9, (3, 3)), src_grid)
+    @test Intp.interpolate(int_nan, (1.5, 4.5)) === 3.0
+    @test eltype(Intp.regrid(int_nan, src_grid)) == Float64
+    @test Intp.regrid(int_nan, src_grid) == reshape(1:9, (3, 3))
 end
 
 @testset "Interpolating and regridding agree" begin

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -1884,6 +1884,112 @@ end
     @test any(ismissing, resampled_missing.data)
 end
 
+@testset "NaN-aware resampling" begin
+    src_long = [0.0, 1.0, 2.0, 3.0]
+    src_var =
+        TemplateVar() |>
+        add_dim("long", src_long, units = "deg") |>
+        add_attribs(long_name = "hi") |>
+        add_data(data = [1.0, NaN, 3.0, 4.0]) |>
+        initialize
+
+    dest_long = [0.25, 2.5]
+    dest_var = ClimaAnalysis.remake(
+        src_var,
+        data = ones(length(dest_long)),
+        dims = OrderedDict("long" => dest_long),
+    )
+
+    # By default, NaNs propagate
+    resampled_var = ClimaAnalysis.resampled_as(src_var, dest_var)
+    @test isequal(resampled_var.data, [NaN, 3.5])
+
+    # At long = 0.25, the NaN contributes 25% of the average, so the result is
+    # NaN only when nan_threshold is smaller than 0.25
+    resampled_var =
+        ClimaAnalysis.resampled_as(src_var, dest_var, nan_threshold = 0.5)
+    @test resampled_var.data == [1.0, 3.5]
+    resampled_var =
+        ClimaAnalysis.resampled_as(src_var, dest_var, nan_threshold = 0.1)
+    @test isequal(resampled_var.data, [NaN, 3.5])
+
+    # NaN at long = 1.0 and lat = 0.0
+    src_var2d =
+        TemplateVar() |>
+        add_dim("long", [0.0, 1.0], units = "deg") |>
+        add_dim("lat", [0.0, 1.0], units = "deg") |>
+        add_attribs(long_name = "hi") |>
+        add_data(data = [1.0 3.0; NaN 5.0]) |>
+        initialize
+
+    # Resampling with keyword arguments
+    resampled_var =
+        ClimaAnalysis.resampled_as(src_var2d, long = [0.5], lat = [0.5])
+    @test isequal(resampled_var.data, reshape([NaN], (1, 1)))
+    resampled_var = ClimaAnalysis.resampled_as(
+        src_var2d,
+        long = [0.5],
+        lat = [0.5],
+        nan_threshold = 0.5,
+    )
+    @test resampled_var.data == reshape([3.0], (1, 1))
+
+    # Partial resampling with dim_names
+    dest_var2d = ClimaAnalysis.remake(
+        src_var2d,
+        data = ones(1, 2),
+        dims = OrderedDict("long" => [0.5], "lat" => [0.0, 1.0]),
+    )
+    resampled_var = ClimaAnalysis.resampled_as(
+        src_var2d,
+        dest_var2d,
+        dim_names = "longitude",
+        nan_threshold = 0.5,
+    )
+    @test resampled_var.data == [1.0 4.0]
+
+    # With no NaNs in the data, nan_threshold does not change the result
+    no_nan_var = ClimaAnalysis.remake(src_var, data = [1.0, 2.0, 3.0, 4.0])
+    @test ClimaAnalysis.resampled_as(
+        no_nan_var,
+        dest_var,
+        nan_threshold = 0.5,
+    ).data == ClimaAnalysis.resampled_as(no_nan_var, dest_var).data
+
+    # Resampling ocean-masked data (NaN over the ocean); the number of NaNs
+    # decreases near the coastlines as nan_threshold increases
+    lon = collect(range(-179.5, 179.5, 360))
+    lat = collect(range(-89.5, 89.5, 180))
+    ocean_var =
+        TemplateVar() |>
+        add_dim("lon", lon, units = "deg") |>
+        add_dim("lat", lat, units = "deg") |>
+        add_attribs(long_name = "hi") |>
+        ones_data() |>
+        initialize |>
+        ClimaAnalysis.apply_oceanmask
+    dest_lon = collect(range(-179.0, 179.0, 240))
+    dest_lat = collect(range(-89.0, 89.0, 120))
+    nan_counts = map([nothing, 0.0, 0.2, 0.4, 0.6, 0.8, 1.0]) do nan_threshold
+        resampled_var = ClimaAnalysis.resampled_as(
+            ocean_var,
+            lon = dest_lon,
+            lat = dest_lat,
+            nan_threshold = nan_threshold,
+        )
+        count(isnan, resampled_var.data)
+    end
+    @test issorted(nan_counts, rev = true)
+    @test first(nan_counts) > last(nan_counts)
+
+    # Error handling
+    @test_throws ErrorException ClimaAnalysis.resampled_as(
+        src_var,
+        dest_var,
+        nan_threshold = 2.0,
+    )
+end
+
 @testset "Resampling ongrid and oncenter" begin
     # Checking oncell (1d)
     src_long = 0.0:359.0 |> collect
@@ -2761,8 +2867,15 @@ end
         add_data(data = nan_data) |>
         initialize
 
+    sim_var =
+        TemplateVar() |>
+        add_dim("lon", [0.0, 0.5, 1.0], units = "degrees") |>
+        add_dim("lat", [0.0, 0.5, 1.0], units = "degrees") |>
+        add_attribs(long_name = "idk", short_name = "short", units = "kg") |>
+        initialize
+
     @test_logs (:warn, r"NaNs detected in observational data") ClimaAnalysis.bias(
-        nan_var,
+        sim_var,
         nan_var,
     )
 end
@@ -2852,9 +2965,15 @@ end
         add_attribs(long_name = "idk", short_name = "short", units = "kg") |>
         add_data(data = nan_data) |>
         initialize
+    sim_var =
+        TemplateVar() |>
+        add_dim("lon", [0.0, 0.5, 1.0], units = "degrees") |>
+        add_dim("lat", [0.0, 0.5, 1.0], units = "degrees") |>
+        add_attribs(long_name = "idk", short_name = "short", units = "kg") |>
+        initialize
 
     @test_logs (:warn, r"NaNs detected in observational data") ClimaAnalysis.squared_error(
-        nan_var,
+        sim_var,
         nan_var,
     )
 end


### PR DESCRIPTION
closes https://github.com/CliMA/ClimaAnalysis.jl/issues/138 and closes https://github.com/CliMA/ClimaAnalysis.jl/issues/198 - This PR adds NaN aware regridding with the `nan_threshold` keyword argument. As `nan_threshold` increases, the number of `NaN`s decrease. 

This is done by summing the weights that the `NaN`s contributed. If the sum is greater than the `NaN` threshold, then the resulting value is a `NaN`. Otherwise, it is the weighted average of the non-`NaN` values.

A LLM implemented this and I went through and verified it.

TODO

1. Think about how `resampled_as` should be handled for functions that compute error metrics