### PR TITLE
Fix bug in flatten and unflatten for 0D OutputVar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,10 @@ coastlines become `NaN`. Passing a value from 0 to 1 for `nan_threshold` fix
 this problem. For more information, see the section "How do I resample data
 that contains NaNs?" in the documentation.
 
+## Bug fixes
+
+- Fix a bug where `unflatten` did not work with `OutputVar`s with no dimensions.
+
 v0.5.23
 -------
 

--- a/src/flat.jl
+++ b/src/flat.jl
@@ -247,10 +247,15 @@ function unflatten(metadata::Metadata, data::AbstractVector)
         dim_name => index for
         (index, dim_name) in enumerate(keys(metadata.dims))
     )
+    # Pass Int to collect since invperm does not work with vector whose eltype
+    # is Any
     perm = invperm(
-        collect(dim2index[dim_name] for dim_name in metadata.ordered_dims),
+        collect(Int, dim2index[dim_name] for dim_name in metadata.ordered_dims),
     )
-    data = permutedims(unflattened_data, perm)
+    # permutedims errors on 0-dim arrays on Julia 1.10
+    data =
+        ndims(unflattened_data) == 0 ? copy(unflattened_data) :
+        permutedims(unflattened_data, perm)
 
     return OutputVar(
         deepcopy(metadata.attributes),

--- a/test/test_flat.jl
+++ b/test/test_flat.jl
@@ -242,6 +242,43 @@ import ClimaAnalysis.Template:
     )
 end
 
+@testset "Flatten and unflatten OutputVar with no dimensions" begin
+    var =
+        TemplateVar() |>
+        add_attribs(short_name = "ts", units = "K") |>
+        add_data(data = fill(300.0)) |>
+        initialize
+
+    flat_var = ClimaAnalysis.flatten(var)
+    @test ClimaAnalysis.flatten_dim_order(flat_var) == ()
+    @test ClimaAnalysis.flattened_length(flat_var) == 1
+    @test flat_var.data == [300.0]
+    @test flat_var.metadata.attributes == var.attributes
+    @test flat_var.metadata.dims == var.dims
+    @test flat_var.metadata.dim_attributes == var.dim_attributes
+
+    unflatten_var = ClimaAnalysis.unflatten(flat_var)
+    @test unflatten_var.data == var.data
+    @test ndims(unflatten_var.data) == 0
+    @test unflatten_var.attributes == var.attributes
+    @test unflatten_var.dim_attributes == var.dim_attributes
+    @test unflatten_var.dims == var.dims
+
+    # Flatten with metadata
+    flat_var2 = ClimaAnalysis.flatten(var, flat_var.metadata)
+    @test flat_var2.data == flat_var.data
+
+    @test ClimaAnalysis.Var.arecompatible(flat_var.metadata, flat_var2.metadata)
+
+    # OutputVar with no dimensions whose data is NaN
+    nan_var = ClimaAnalysis.remake(var, data = fill(NaN))
+    flat_nan_var = ClimaAnalysis.flatten(nan_var)
+    @test ClimaAnalysis.flattened_length(flat_nan_var) == 0
+    unflatten_nan_var = ClimaAnalysis.unflatten(flat_nan_var)
+    @test isequal(unflatten_nan_var.data, nan_var.data)
+    @test ndims(unflatten_nan_var.data) == 0
+end
+
 @testset "Flatten with metadata" begin
     lat = [-90.0, -30.0, 30.0, 90.0]
     lon = [-60.0, -30.0, 0.0, 30.0, 60.0]


### PR DESCRIPTION
This PR fixes a bug with `flatten` and `unflatten` not working properly for zero dimensional `OutputVar`s.