### PR TITLE
Add Var.propagate_nans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,19 @@ coastlines become `NaN`. Passing a value from 0 to 1 for `nan_threshold` fix
 this problem. For more information, see the section "How do I resample data
 that contains NaNs?" in the documentation.
 
+## Propagate NaNs
+
+With this release, you can use `propagate_nans` or `propagate_nans!` to fill
+slices over dimensions with `NaN`s whenever any other slice over the same
+dimensions contains a `NaN` at the same coordinates. This is useful when
+computing statistics over data whose `NaN`s vary between slices, such as
+observational data with missing measurements at different times.
+
+```julia
+# Every time slice of var_nans has NaNs at the same coordinates
+var_nans = ClimaAnalysis.propagate_nans(var, dims = "time")
+```
+
 ## Bug fixes
 
 - Fix a bug where `unflatten` did not work with `OutputVar`s with no dimensions.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -122,6 +122,8 @@ Base.replace(var::OutputVar, old_new::Pair...; count::Integer)
 Base.replace(new::Union{Function, Type}, var::OutputVar; count::Integer)
 Base.replace!(var::OutputVar, old_new::Pair...; count::Integer)
 Base.replace!(new::Union{Function, Type}, var::OutputVar; count::Integer)
+Var.propagate_nans
+Var.propagate_nans!
 Base.cat(vars::OutputVar...; dim::String)
 Var.reverse_dim
 Var.reverse_dim!

--- a/docs/src/howdoi.md
+++ b/docs/src/howdoi.md
@@ -453,6 +453,49 @@ a `OutputVar` with 0.0. See the example below of this usage.
 var_no_nan_and_missing = replace(var, missing => 0.0, NaN => 0.0)
 ```
 
+## How do I make `NaN`s consistent across slices of a `OutputVar`?
+
+You can use [`propagate_nans`](@ref) or [`propagate_nans!`](@ref) to fill all
+slices of the `OutputVar` with `NaN`s whenever any other slice over the same
+dimensions contains a `NaN`. For example, if you pass `dims = "time"` to the
+function, then every time slice of the result has `NaN`s at the same
+coordinates. This is useful when you are computing statistics over data whose
+`NaN` vary between slices, such as observational data with missing measurements
+at different times.
+
+```@setup propagate_nans
+import ClimaAnalysis
+import ClimaAnalysis.Template:
+    TemplateVar,
+    add_attribs,
+    add_dim,
+    add_data,
+    initialize
+
+time = [0.0, 1.0, 2.0]
+lat = collect(range(-90.0, 90.0, 4))
+data = ones(length(time), length(lat))
+data[1, 2] = NaN
+data[3, 4] = NaN
+var =
+    TemplateVar() |>
+    add_dim("time", time, units = "s") |>
+    add_dim("lat", lat, units = "degrees_north") |>
+    add_attribs(short_name = "pr") |>
+    add_data(data = data) |>
+    initialize
+```
+
+In the example below, each row of `var.data` is a time slice. After calling
+`propagate_nans`, a column is entirely `NaN`s if any other slice at the same
+non-temporal coordinates contain a `NaN`.
+
+```@repl propagate_nans
+var.data
+var_nans = ClimaAnalysis.propagate_nans(var, dims = "time");
+var_nans.data
+```
+
 ## How do I reverse a dimension so that an interpolant can be made?
 
 You can use `reverse_dim` or `reverse_dim!` to reverse a dimension by name. See

--- a/src/Var.jl
+++ b/src/Var.jl
@@ -79,6 +79,8 @@ export OutputVar,
     set_reference_date!,
     replace,
     replace!,
+    propagate_nans,
+    propagate_nans!,
     reverse_dim,
     reverse_dim!,
     remake,
@@ -2844,6 +2846,52 @@ function Base.replace!(
     count::Integer = typemax(Int),
 )
     replace!(new, var.data, count = count)
+    return nothing
+end
+
+"""
+    propagate_nans(var::OutputVar; dims = ("time",))
+
+Propagate `NaN`s for slices over `dims` for `var`.
+
+If the data contains a `NaN` anywhere along a slice over `dims`, then the entire
+slice is filled with `NaN`s. For example, if `dims = "time"` is passed to
+`propagate_nans`, then any time slice of the resulting `OutputVar` will have
+NaNs at the same coordinates as any other time slices of resulting `OutputVar`.
+
+!!! note "Missing values"
+    If `missing` is in the data of `var`, then you should use [`replace`](@ref)
+    or [`replace!`](@ref) to replace `missing` values with `NaN`s. Note that
+    `missing` is preserved, since `missing * NaN == missing`.
+
+See also [`propagate_nans!`](@ref).
+"""
+function propagate_nans(var::OutputVar; dims = ("time",))
+    var = deepcopy(var)
+    propagate_nans!(var; dims)
+    return var
+end
+
+"""
+    propagate_nans!(var::OutputVar; dims = ("time",))
+
+In-place version of [`propagate_nans`](@ref).
+"""
+function propagate_nans!(var::OutputVar; dims = ("time",))
+    dims isa AbstractString && (dims = (dims,))
+    dim_names = collect(
+        find_corresponding_dim_name_in_var(dim_name, var) for dim_name in dims
+    )
+    allunique(dim_names) || error("Dimensions ($dim_names) must be unique")
+
+    dim_indices = Tuple(var.dim2index[dim_name] for dim_name in dim_names)
+
+    FT = nonmissingtype(eltype(var.data))
+    nan_mask = map(
+        contains_nan -> contains_nan ? FT(NaN) : one(FT),
+        any(x -> !ismissing(x) && isnan(x), var.data, dims = dim_indices),
+    )
+    var.data .*= nan_mask
     return nothing
 end
 

--- a/test/test_Var.jl
+++ b/test/test_Var.jl
@@ -3709,6 +3709,94 @@ end
     @test isequal(var2.data, [2.0, 2.0, NaN])
 end
 
+@testset "Propagate NaNs" begin
+    var =
+        TemplateVar() |>
+        add_time_dim(dim = [1.0, 2.0]) |>
+        add_lon_dim(dim = [-60.0, 0.0, 60.0]) |>
+        add_lat_dim(dim = [-30.0, 0.0, 30.0]) |>
+        add_attribs(long_name = "hi") |>
+        one_to_n_data(collected = true) |>
+        initialize
+
+    no_nan_var = ClimaAnalysis.propagate_nans(var)
+    @test var == no_nan_var
+
+    # NaNs in different time slices
+    nan_var = deepcopy(var)
+    nan_var.data[1, 1, 1] = NaN
+    nan_var.data[2, 3, 2] = NaN
+
+    expected_data = copy(nan_var.data)
+    expected_data[:, 1, 1] .= NaN
+    expected_data[:, 3, 2] .= NaN
+    propagated_nan_var = ClimaAnalysis.propagate_nans(nan_var, dims = "time")
+    @test isequal(propagated_nan_var.data, expected_data)
+
+    # Input var is not modified and does not share data with the result
+    @test count(isnan, nan_var.data) == 2
+    propagated_nan_var.data[1, 2, 2] = 42.0
+    @test nan_var.data[1, 2, 2] != 42.0
+
+    # Different name for time
+    propagated_alias_var = ClimaAnalysis.propagate_nans(nan_var, dims = "t")
+    @test isequal(propagated_alias_var.data, expected_data)
+
+    # Missing values pass through unchanged and do not propagate
+    missing_data = convert(Array{Union{Missing, Float64}}, nan_var.data)
+    missing_data[1, 1, 1] = missing
+    missing_var = ClimaAnalysis.remake(nan_var, data = missing_data)
+    expected_missing_data = copy(missing_data)
+    expected_missing_data[:, 3, 2] .= NaN
+    propagated_missing_var = ClimaAnalysis.propagate_nans(missing_var)
+    @test isequal(propagated_missing_var.data, expected_missing_data)
+
+    # Slice with both missing and NaN: NaN propagates and missing is preserved
+    mixed_data = copy(missing_data)
+    mixed_data[1, 1, 2] = missing
+    mixed_var = ClimaAnalysis.remake(nan_var, data = mixed_data)
+    expected_mixed_data = copy(mixed_data)
+    expected_mixed_data[:, :, 2] .= NaN
+    expected_mixed_data[1, 1, 2] = missing
+    propagated_mixed_var =
+        ClimaAnalysis.propagate_nans(mixed_var, dims = ("time", "lon"))
+    @test isequal(propagated_mixed_var.data, expected_mixed_data)
+
+    # Propagate NaNs for multiple dimensions
+    expected_data = copy(nan_var.data)
+    expected_data[:, 1, :] .= NaN
+    expected_data[:, 3, :] .= NaN
+    propagated_nan_var2 =
+        ClimaAnalysis.propagate_nans(nan_var, dims = ("time", "lat"))
+    @test isequal(propagated_nan_var2.data, expected_data)
+
+    propagated_nan_var3 =
+        ClimaAnalysis.propagate_nans(nan_var, dims = ("lat", "time", "lon"))
+    @test all(isnan.(propagated_nan_var3.data))
+
+    # Error handling
+    @test_throws ErrorException ClimaAnalysis.propagate_nans(
+        nan_var,
+        dims = "no_dim",
+    )
+    @test_throws ErrorException ClimaAnalysis.propagate_nans(
+        nan_var,
+        dims = ("time", "t"),
+    )
+
+    # Test in-place version of propagate_nans
+    expected_data = copy(nan_var.data)
+    expected_data[:, 1, 1] .= NaN
+    expected_data[:, 3, 2] .= NaN
+    ClimaAnalysis.propagate_nans!(nan_var)
+    @test isequal(nan_var.data, expected_data)
+
+    expected_data[:, 1, :] .= NaN
+    expected_data[:, 3, :] .= NaN
+    ClimaAnalysis.propagate_nans!(nan_var, dims = ("lat", "time"))
+    @test isequal(nan_var.data, expected_data)
+end
+
 @testset "Concatenate OutputVars" begin
     # Initialize 3D OutputVar (lon, lat, time)
     times = Float64[


### PR DESCRIPTION
This PR adds `Var.propagate_nans` which let the users propagate `NaN` across the slices of a `OutputVar`. This functionality is used in calibration because the observational data has `NaN`s at different non-temporal coordinates across the time slices of the `OutputVar`. To build a matrix of samples, we need to either do imputation or propagate the `NaN`s over the samples. The latter solution is implemented.