### PR TITLE
Remove Julia 1.11 and use Julia 1.13 for CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.11'
           - '1.12'
+          - '1.13'
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -20,13 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ['1.10', '1.11', '1.12']
+        version: ['1.10', '1.12', '1.13']
         include:
           # Old Makie (CairoMakie 0.12 / Makie 0.21) reads Core.TypeName.mt,
           # which Julia 1.12 removed, so don't downgrade the Makie and its
           # related packages here. This allows for using ClimaAnalysis with
           # older versions of Makie and its related packages.
           - version: '1.12'
+            skip_extra: ', CairoMakie, Makie, GeoMakie'
+          - version: '1.13'
             skip_extra: ', CairoMakie, Makie, GeoMakie'
     steps:
       - uses: actions/checkout@v7

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -651,6 +651,6 @@ have default keyword arguments.
 
 See: https://discourse.julialang.org/t/multi-layer-dict-merge/27261/6
 """
-_recursive_merge(x::AbstractDict...) = merge(_recursive_merge, x...)
+_recursive_merge(x::AbstractDict...) = mergewith(_recursive_merge, x...)
 _recursive_merge(x...) = x[end]
 end

--- a/test/test_Sim.jl
+++ b/test/test_Sim.jl
@@ -71,10 +71,32 @@ end
 
     simdir = ClimaAnalysis.SimDir(simulation_path)
 
-    @test sprint(show, simdir) ==
-          "Output directory: " *
-          simulation_path *
-          "\nVariables:\n- va\n    average (2.0h)\n- pfull\n    inst (1.0d)\n- ua\n    average (6.0h)\n- orog\n    inst (nothing)\n- thetaa\n    average (1d)\n- ta\n    average (3.0h)\n    max (4.0h, 3.0h)\n    min (3.0h)\n- ts\n    max (1.0h)"
+    # Dict iteration order varies across Julia versions, so compare the lines of
+    # each variable block as sets. The two periods of ta max can also come in
+    # either order, so both are listed
+    header, blocks... = split(sprint(show, simdir), "\n- ")
+    @test header == "Output directory: $simulation_path\nVariables:"
+    @test length(blocks) == 7
+    @test Set(Set(split(block, "\n")) for block in blocks) ⊆ Set([
+        Set(["va", "    average (2.0h)"]),
+        Set(["pfull", "    inst (1.0d)"]),
+        Set(["ua", "    average (6.0h)"]),
+        Set(["orog", "    inst (nothing)"]),
+        Set(["thetaa", "    average (1d)"]),
+        Set([
+            "ta",
+            "    average (3.0h)",
+            "    max (4.0h, 3.0h)",
+            "    min (3.0h)",
+        ]),
+        Set([
+            "ta",
+            "    average (3.0h)",
+            "    max (3.0h, 4.0h)",
+            "    min (3.0h)",
+        ]),
+        Set(["ts", "    max (1.0h)"]),
+    ])
     @test sprint(summary, simdir) == sprint(show, simdir)
 
     # Empty simdir


### PR DESCRIPTION
This PR fixes the deprecation with `merge` and a test that depends on the ordering of items in a dictionary. Julia 1.11 was removed from the CI because testing four different Julia versions seems excessive. Julia 1.10 is still tested because it is the long term support (LTS).